### PR TITLE
feat: add setup script and pinned deps

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pip install -r "$(dirname "$0")/../requirements.txt"
+
+exit 0

--- a/NOTES.md
+++ b/NOTES.md
@@ -25,3 +25,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: establish collaboration conventions before code.
 - **Next step**: set up lint/test commands and begin core feature A.
 
+
+## 2025-08-11  PR #1
+
+- **Summary**: added setup script and pinned dependency manifest.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure consistent environment.
+- **Next step**: configure lint and test commands.
+

--- a/TODO.md
+++ b/TODO.md
@@ -8,11 +8,11 @@
 ## 0 · Project bootstrap
 - [ ] Commit starter governance files (`AGENTS.md`, `TODO.md`, `NOTES.md`,
       minimal CI)
-- [ ] Add `.codex/setup.sh`; ensure it is idempotent and exits 0
+- [x] Add `.codex/setup.sh`; ensure it is idempotent and exits 0
 - [ ] Configure `make lint` and `make test` (cover every language tool‑chain)
 - [ ] Audit repository & docs; identify the single source of truth
       (spec, assignment …) and reference it in README
-- [ ] Generate initial dependency manifests (`requirements.txt`,
+- [x] Generate initial dependency manifests (`requirements.txt`,
       `package.json`, `pubspec.yaml`, …) with pinned versions
 - [ ] Define ownership of all generated code in `/generated/**` and record the
       regeneration command in `AGENTS.md`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+dlt[duckdb]==1.15.0
+duckdb==1.3.2
+pytest==8.4.1
+


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` for installing pinned dependencies
- pin `dlt[duckdb]`, `duckdb`, and `pytest` in `requirements.txt`
- record progress in `NOTES.md` and tick matching TODO items

## Testing
- `./.codex/setup.sh`
- `make lint` *(fails: No rule to make target 'lint')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6899d5c3ae4483258403b53bc2db64c8