### PR TITLE
docs: add quick-start and roadmap notes

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -8,7 +8,7 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 
 ## TEMPLATE  (copy → fill → append)
 
-### YYYY‑MM‑DD  PR #<number or draft>
+### YYYY‑MM‑DD  PR #&lt;number or draft&gt;
 
 - **Summary**: one‑sentence description of what changed.
 - **Stage**: planning / implementation / testing / maintenance / release
@@ -17,7 +17,7 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 
 ---
 
-## 2025‑01‑01  PR #0  🌱 _file created_
+## 2025‑01‑01  PR #0  🌱 *file created*
 
 - **Summary**: Seeded repository with starter templates (`AGENTS.md`, `TODO.md`,
   `NOTES.md`) and minimal CI workflow.
@@ -25,3 +25,9 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: establish collaboration conventions before code.
 - **Next step**: set up lint/test commands and begin core feature A.
 
+## 2025-08-11  PR #1
+
+- **Summary**: Expanded README with setup instructions, tests, and design notes.
+- **Stage**: documentation
+- **Motivation / Decision**: Align docs with specs to guide future work.
+- **Next step**: Implement GitHub commits pipeline.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# DLT_challenge
+# GitHub commit leaderboard pipeline
+
+This project is a small [dlt](https://dlthub.com/) pipeline that loads recent
+GitHub commits into DuckDB and builds a daily leaderboard of contributors.
+
+It creates three tables:
+
+* `commits_raw`
+* `commits_flat`
+* `leaderboard_daily`
+
+## Quick start (Windows PowerShell)
+
+1. `cd gh-leaderboard`
+2. `py -m venv .venv`
+3. `. .\\.venv\\Scripts\\Activate.ps1`
+4. `pip install -r requirements.txt`
+5. `python -m src.gh_leaderboard.pipeline`
+
+## Quick start (Linux / macOS / WSL)
+
+1. `cd gh-leaderboard`
+2. `python3 -m venv .venv`
+3. `source .venv/bin/activate`
+4. `pip install -r requirements.txt`
+5. `python -m src.gh_leaderboard.pipeline`
+
+Set `GITHUB_TOKEN` to raise rate limits if needed.
+
+## Tests
+
+Run unit and end-to-end tests:
+
+```bash
+pytest -q
+```
+
+## Incremental loads
+
+The resource uses `commit.committer.date` as the cursor and falls back to the
+author date. dlt stores the last cursor so pass `--since` on the next run.
+
+## Design decisions
+
+* Local DuckDB keeps dependencies minimal.
+* Link header pagination walks through commit pages.
+* The cursor uses commit times to enable incremental syncs.
+* Author identity falls back from login to email to name.

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,12 @@
-# TODO – Road‑map  (last updated: YYYY‑MM‑DD)
+# TODO – Road‑map  (last updated: 2025-08-11)
 
-> *Record only high‑level milestones here; break micro‑tasks out into Issues.*  
+> *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
-> (see NOTES.md).**  
+> (see NOTES.md).**
 > Keep this list ordered by topic and **never reorder past items**.
 
-## 0 · Project bootstrap
+## 0 · Project bootstrap
+
 - [ ] Commit starter governance files (`AGENTS.md`, `TODO.md`, `NOTES.md`,
       minimal CI)
 - [ ] Add `.codex/setup.sh`; ensure it is idempotent and exits 0
@@ -18,31 +19,38 @@
       regeneration command in `AGENTS.md`
 - [ ] Push the first green CI run (docs‑only + full‑tests job)
 
-## 1 · Core functionality  
-*Repeat the five‑bullet block below for every MVP feature A, B, C, …*  
-- [ ] Analyse source‑of‑truth docs; define acceptance criteria for **feature A**  
-- [ ] Document assumptions / edge‑cases for feature A in `/docs` or README  
-- [ ] Implement feature A  
-- [ ] Add unit / integration tests for feature A  
+## 1 · Core functionality
+
+*Repeat the five‑bullet block below for every MVP feature A, B, C, …*
+
+- [ ] Analyse source‑of‑truth docs; define acceptance criteria for
+      **GitHub commits pipeline**
+- [ ] Document assumptions / edge‑cases for GitHub commits pipeline in
+       `/docs` or README
+- [ ] Implement GitHub commits pipeline
+- [ ] Add unit / integration tests for GitHub commits pipeline
 - [ ] Wire CI quality gate (coverage ≥ 80 %, metric thresholds, etc.) that
       exits 1 on regression
 
-## 2 · Documentation & CI
-- [ ] Write README quick‑start (clone → setup → test)
+## 2 · Documentation & CI
+
+- [x] Write README quick‑start (clone → setup → test)
 - [ ] Add full doc build (Sphinx / JSDoc / dart‑doc as applicable)
 - [ ] Integrate secret‑detection helper step in CI (`has_token` pattern)
 - [ ] Extend CI matrix for all runtimes (Python, Node, Dart, Rust, …)
 - [ ] Add Actionlint + markdown‑link‑check jobs and pin their versions
 - [ ] Publish docs to GitHub Pages when `GH_PAGES_TOKEN` is present
 
-## 3 · Quality & automation
+## 3 · Quality & automation
+
 - [ ] Add pre‑commit hooks (formatters, linters, markdownlint, actionlint)
 - [ ] Enforce coverage threshold (≥ 80 % branch, exclude `/generated/**`)
 - [ ] Add linters for conflict markers, trailing spaces and NOTES ordering
 - [ ] Introduce dependabot / Renovate with the version‑pin policy from
       `AGENTS.md`
 
-## 4 · Stretch goals
+## 4 · Stretch goals
+
 - [ ] Containerise dev environment (Dockerfile or dev‑container.json)
 - [ ] Auto‑deploy docs & storybooks on each tag
 - [ ] Publish packages (PyPI, npm, pub.dev) via release workflow
@@ -50,5 +58,6 @@
 
 ---
 
-### Add new items below this line  
-*(append only; keep earlier history intact)*
+### Add new items below this line
+
+(append only; keep earlier history intact)


### PR DESCRIPTION
## Summary
- expand README with project intro, platform setup, tests, and design notes
- log documentation update in NOTES and refine roadmap

## Testing
- `npx --yes markdownlint-cli README.md NOTES.md TODO.md`
- `npx --yes markdown-link-check README.md`
- `npx --yes markdown-link-check NOTES.md`
- `npx --yes markdown-link-check TODO.md`
- `git grep -n '<<<<<<<\|=======\|>>>>>>>' -- ':!AGENTS.md'`


------
https://chatgpt.com/codex/tasks/task_e_6899d5cd938c8325899655a6f8d883cf