### PR TITLE
Scaffold gh_leaderboard package

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -25,3 +25,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: establish collaboration conventions before code.
 - **Next step**: set up lint/test commands and begin core feature A.
 
+---
+
+## 2025-08-11  PR #1
+
+- **Summary**: Created gh_leaderboard package skeleton.
+- **Stage**: planning
+- **Motivation / Decision**: start structure for future dlt pipeline.
+- **Next step**: implement GitHub commit pipeline.

--- a/TODO.md
+++ b/TODO.md
@@ -52,3 +52,4 @@
 
 ### Add new items below this line  
 *(append only; keep earlier history intact)*
+- [ ] Implement GitHub leaderboard pipeline in `src/gh_leaderboard`

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Project source code package."""

--- a/src/gh_leaderboard/__init__.py
+++ b/src/gh_leaderboard/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub leaderboard pipeline package."""

--- a/src/gh_leaderboard/pipeline.py
+++ b/src/gh_leaderboard/pipeline.py
@@ -1,0 +1,6 @@
+"""Placeholder for GitHub leaderboard dlt pipeline."""
+
+
+def run() -> None:
+    """Entry point for the future pipeline."""
+    raise NotImplementedError("Pipeline not implemented yet.")


### PR DESCRIPTION
## Summary
- scaffold `gh_leaderboard` package with placeholder pipeline entrypoint
- note package creation in NOTES and add roadmap item for pipeline work

## Testing
- `bash .codex/setup.sh` *(fails: No such file or directory)*
- `make lint` *(fails: No rule to make target 'lint')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6899d5d39cc883258db2cd4bcec70be7