### PR TITLE
docs: fix repo path and reference master specs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -67,3 +67,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: implementation
 - **Motivation / Decision**: ensure consistent environment.
 - **Next step**: configure lint and test commands.
+
+## 2025-08-11  PR #7
+
+- **Summary**: Replaced placeholder repo path and linked master spec.
+- **Stage**: documentation
+- **Motivation / Decision**: keep instructions accurate and reference single source
+  of truth.
+- **Next step**: implement GitHub commits pipeline.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This project is a small [dlt](https://dlthub.com/) pipeline that loads recent
 GitHub commits into DuckDB and builds a daily leaderboard of contributors.
 
+See [docs/specs.txt](docs/specs.txt) for the master specification.
+
 It creates three tables:
 
 * `commits_raw`
@@ -11,7 +13,7 @@ It creates three tables:
 
 ## Quick start (Windows PowerShell)
 
-1. `cd gh-leaderboard`
+1. `cd DLT_challenge`
 2. `py -m venv .venv`
 3. `. .\\.venv\\Scripts\\Activate.ps1`
 4. `pip install -r requirements.txt`
@@ -19,7 +21,7 @@ It creates three tables:
 
 ## Quick start (Linux / macOS / WSL)
 
-1. `cd gh-leaderboard`
+1. `cd DLT_challenge`
 2. `python3 -m venv .venv`
 3. `source .venv/bin/activate`
 4. `pip install -r requirements.txt`

--- a/TODO.md
+++ b/TODO.md
@@ -9,8 +9,8 @@
 - [x] Configure `make lint` and `make test` (cover every language tool‑chain)
 - [x] Commit starter governance files (`AGENTS.md`, `TODO.md`, `NOTES.md`,
 - [x] Add `.codex/setup.sh`; ensure it is idempotent and exits 0
-- [ ] Audit repository & docs; identify the single source of truth
-      (spec, assignment …) and reference it in README
+- [x] Audit repository & docs; identify the single source of truth
+       (spec, assignment …) and reference it in README
 - [x] Generate initial dependency manifests (`requirements.txt`,
       `package.json`, `pubspec.yaml`, …) with pinned versions
 - [ ] Define ownership of all generated code in `/generated/**` and record the
@@ -19,7 +19,7 @@
 
 ## 1 · Core functionality
 
-*Repeat the five‑bullet block below for every MVP feature A, B, C, …*
+Repeat the five‑bullet block below for every MVP feature A, B, C, …
 
 - [ ] Analyse source‑of‑truth docs; define acceptance criteria for
       **GitHub commits pipeline**

--- a/docs/specs.txt
+++ b/docs/specs.txt
@@ -249,10 +249,10 @@ Copy
 pytest -q -k e2e --offline
 Query the DuckDB file produced (e.g., gh_leaderboard.duckdb) to show leaderboard_daily.
 
-B) Local (Windows 11 PowerShell)
+ B) Local (Windows 11 PowerShell)
 powershell
 Copy
-cd gh-leaderboard
+cd DLT_challenge
 py -m venv .venv
 . .\.venv\Scripts\Activate.ps1
 pip install --upgrade pip
@@ -267,7 +267,7 @@ pytest -q
 C) Local (Linux/macOS / WSL)
 bash
 Copy
-cd gh-leaderboard
+cd DLT_challenge
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- fix quick-start steps to use repo path `DLT_challenge`
- link master spec `docs/specs.txt` from README
- note completion of repository audit in TODO and NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `find . -name '*.md' -print0 | xargs -0 -n1 npx --yes markdown-link-check`


------
https://chatgpt.com/codex/tasks/task_e_6899e00f80688325bed6eee78dec9166