### PR TITLE
fix: provision venv and lint tools in setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-pip install -r "$(dirname "$0")/../requirements.txt"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ ! -d "${REPO_ROOT}/.venv" ]; then
+    python -m venv "${REPO_ROOT}/.venv"
+fi
+
+"${REPO_ROOT}/.venv/bin/pip" install -r "${REPO_ROOT}/requirements.txt"
 
 exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.3 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.4 -->
 
 > **Read this file first** before opening a pull‑request.  
 > It defines the ground rules that keep humans, autonomous agents and CI in‑sync.  
@@ -31,8 +31,8 @@ repo and run in local IDE ()Visual Studion 2022 on Win 11) to test manually.
 
 ## 2 · Bootstrap (first‑run) checklist
 
-1. Run `.codex/setup.sh` (or `./setup.sh`) once after cloning & whenever dependencies change.  
-   *The script installs language tool‑chains, pins versions and injects secrets.*  
+1. Run `.codex/setup.sh` (or `./setup.sh`) once after cloning & whenever dependencies change.
+   *The script creates `.venv/` and installs runtime, lint & test dependencies.*
 2. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …) in the repository/organisation **Secrets** console.  
 3. Verify the **secret‑detection helper step** in `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.  
 4. On the first PR, update README badges to point at your fork (owner/repo).

--- a/NOTES.md
+++ b/NOTES.md
@@ -91,3 +91,12 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: keep instructions accurate and reference single source
   of truth.
 - **Next step**: implement GitHub commits pipeline.
+
+## 2025-08-11  PR #10
+
+- **Summary**: `.codex/setup.sh` now provisions `.venv` with black and ruff so
+  `make lint` runs.
+- **Stage**: implementation
+- **Motivation / Decision**: lint step failed due to missing virtual
+  environment; installing tools in `.venv` isolates dependencies.
+- **Next step**: run CI to confirm lint and tests pass.

--- a/TODO.md
+++ b/TODO.md
@@ -62,3 +62,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [ ] Implement GitHub leaderboard pipeline in `src/gh_leaderboard`
 - [ ] Fix markdownlint errors across docs to make `lint-docs` job pass
 - [x] Require `make test` to fail when no tests are collected (2025-08-11)
+- [x] Ensure `.codex/setup.sh` creates `.venv` with lint tools (2025-08-11)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 dlt[duckdb]==1.15.0
 duckdb==1.3.2
 pytest==8.4.1
+black==24.4.2
+ruff==0.5.4
 


### PR DESCRIPTION
## Summary
- ensure `.codex/setup.sh` creates `.venv` and installs black/ruff
- document venv setup in AGENTS
- record fix in TODO and NOTES

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6899e66656bc83259685e157ebb81b74