### PR TITLE
test: import pipeline without sys path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.3 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.4 -->
 
 > **Read this file first** before opening a pull‑request.  
 > It defines the ground rules that keep humans, autonomous agents and CI in‑sync.  
@@ -126,9 +126,10 @@ jobs:
 * ≤ 20 logical LOC per function, ≤ 2 nesting levels.  
 * Surround headings / lists / fenced code with a blank line (markdownlint MD022, MD032).  
 * **No trailing spaces.** Run `git diff --check` or `make lint-docs`.  
-* Wrap identifiers like `__init__` in back‑ticks to avoid MD050.  
-* Each public API carries a short doc‑comment.  
+* Wrap identifiers like `__init__` in back‑ticks to avoid MD050.
+* Each public API carries a short doc‑comment.
 * Keep Markdown lines ≤ 80 chars to improve diff readability (tables may exceed if unavoidable).
+* Import project modules via the `src` package and never modify `sys.path` in tests.
 
 ### 5.1 Additional instructions:
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -91,3 +91,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: keep instructions accurate and reference single source
   of truth.
 - **Next step**: implement GitHub commits pipeline.
+
+## 2025-08-11  PR #10
+
+- **Summary**: Rewrote pipeline test to import via `src` package and removed path tweaks.
+- **Stage**: testing
+- **Motivation / Decision**: avoid `sys.path` hacks and document rule in AGENTS.
+- **Next step**: implement GitHub commits pipeline.

--- a/TODO.md
+++ b/TODO.md
@@ -62,3 +62,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [ ] Implement GitHub leaderboard pipeline in `src/gh_leaderboard`
 - [ ] Fix markdownlint errors across docs to make `lint-docs` job pass
 - [x] Require `make test` to fail when no tests are collected (2025-08-11)
+- [x] Remove `sys.path` manipulation in tests and use package imports (2025-08-11)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,10 +1,6 @@
-from pathlib import Path
-import sys
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-
-from gh_leaderboard.pipeline import run
+from src.gh_leaderboard.pipeline import run
 
 
 def test_run_not_implemented() -> None:


### PR DESCRIPTION
## Summary
- import `run` from `src.gh_leaderboard.pipeline` in tests
- document package-import rule in AGENTS
- log change in NOTES and TODO

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6899e669a4708325b442f8fef4c78c05