### PR TITLE
Pin requests dependency and fix AGENTS list numbering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.4 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.5 -->
 
 > **Read this file first** before opening a pull‑request.  
 > It defines the ground rules that keep humans, autonomous agents and CI in‑sync.  
@@ -38,9 +38,9 @@ repo and run in local IDE ()Visual Studion 2022 on Win 11) to test manually.
    `.venv/bin/pip install -r requirements.txt`.
    Run `.codex/setup.sh` after activating; the Makefile uses `.venv/bin`.
    *The script installs language tool‑chains, pins versions and injects secrets.*
-2. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …) in the repository/organisation **Secrets** console.  
-3. Verify the **secret‑detection helper step** in `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.  
-4. On the first PR, update README badges to point at your fork (owner/repo).
+1. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …) in the repository/organisation **Secrets** console.  
+1. Verify the **secret‑detection helper step** in `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.  
+1. On the first PR, update README badges to point at your fork (owner/repo).
 
 ---
 
@@ -130,6 +130,7 @@ jobs:
 * 4‑space indent (or 2‑spaces for JS/TS when enforced by the linter).  
 * ≤ 20 logical LOC per function, ≤ 2 nesting levels.  
 * Surround headings / lists / fenced code with a blank line (markdownlint MD022, MD032).  
+* Use `1.` for every item in ordered lists (markdownlint MD029).
 * **No trailing spaces.** Run `git diff --check` or `make lint-docs`.  
 * Wrap identifiers like `__init__` in back‑ticks to avoid MD050.  
 * Each public API carries a short doc‑comment.  

--- a/NOTES.md
+++ b/NOTES.md
@@ -108,3 +108,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: Needed real data; used Link headers and stored the
   last cursor in a state file.
 - **Next step**: Load results into DuckDB and build SQL leaderboard.
+
+## 2025-08-11  PR #12
+
+- **Summary**: Pinned `requests` dependency and documented ordered list style.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensure stable HTTP client; clarify list numbering to satisfy markdownlint.
+- **Next step**: apply `requests` in future pipeline features.
+

--- a/TODO.md
+++ b/TODO.md
@@ -64,3 +64,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Implement GitHub leaderboard pipeline in `src/gh_leaderboard`
 - [ ] Fix markdownlint errors across docs to make `lint-docs` job pass
 - [ ] Add DuckDB destination and post-load SQL for leaderboard
+- [x] Pin `requests` dependency for HTTP calls (2025-08-11)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ duckdb==1.3.2
 pytest==8.4.1
 black==24.4.2
 ruff==0.5.4
+requests==2.32.4
 


### PR DESCRIPTION
## Summary
- pin `requests==2.32.4` in requirements
- correct AGENTS bootstrap list numbering
- log dependency change in NOTES and TODO

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6899eb5c1f108325996017c5609b937e