### PR TITLE
docs: reference dlt guide in agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.5 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.6 -->
 
 > **Read this file first** before opening a pull‑request.  
 > It defines the ground rules that keep humans, autonomous agents and CI in‑sync.  
@@ -137,6 +137,9 @@ jobs:
 * Keep Markdown lines ≤ 80 chars to improve diff readability (tables may exceed if unavoidable).
 
 ### 5.1 Additional instructions:
+
+* Any work involving dlt must consult `docs/dlt_guide_for_codex_2025.txt` for
+  pipeline, resource, incremental-loading and pagination practices.
 
 Code quality:
 Clear, modular structure

--- a/NOTES.md
+++ b/NOTES.md
@@ -122,3 +122,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: testing
 - **Motivation / Decision**: verify tooling and document results; preparing for green CI.
 - **Next step**: update Makefile to forward pytest flags.
+
+## 2025-08-11  PR #14
+
+- **Summary**: Bumped AGENTS guide to v1.6 and added dlt reference.
+- **Stage**: documentation
+- **Motivation / Decision**: centralise dlt practices using shared guide.
+- **Next step**: follow guide when extending dlt pipelines.

--- a/TODO.md
+++ b/TODO.md
@@ -66,3 +66,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [ ] Add DuckDB destination and post-load SQL for leaderboard
 - [x] Pin `requests` dependency for HTTP calls (2025-08-11)
 - [ ] Allow `make test` to forward flags like `--offline` to pytest (2025-08-11)
+- [ ] Review dlt pipelines per `docs/dlt_guide_for_codex_2025.txt` (2025-08-11)


### PR DESCRIPTION
## Summary
- bump AGENTS guide to v1.6 and require dlt work to follow docs/dlt_guide_for_codex_2025.txt
- log AGENTS change in NOTES and add TODO item to review pipelines against the guide

## Testing
- `./.codex/setup.sh`
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check AGENTS.md`
- `npx --yes markdown-link-check NOTES.md`
- `npx --yes markdown-link-check TODO.md`


------
https://chatgpt.com/codex/tasks/task_e_6899eecdc020832598222b710ced66c8