### PR TITLE
feat: run GitHub commits via dlt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.6 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.7 -->
 
 > **Read this file first** before opening a pull‑request.  
 > It defines the ground rules that keep humans, autonomous agents and CI in‑sync.  
@@ -140,6 +140,9 @@ jobs:
 
 * Any work involving dlt must consult `docs/dlt_guide_for_codex_2025.txt` for
   pipeline, resource, incremental-loading and pagination practices.
+* Run `python -m src.gh_leaderboard.pipeline` to load commits into DuckDB and
+  execute `post_load.sql` producing tables `commits`, `commits_flat`, and
+  `leaderboard_daily`.
 
 Code quality:
 Clear, modular structure

--- a/NOTES.md
+++ b/NOTES.md
@@ -129,3 +129,12 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: documentation
 - **Motivation / Decision**: centralise dlt practices using shared guide.
 - **Next step**: follow guide when extending dlt pipelines.
+
+## 2025-08-12  PR #15
+
+- **Summary**: Added dlt source with incremental pagination and post-load SQL
+  to materialise `leaderboard_daily` in DuckDB; updated tests and README.
+- **Stage**: implementation
+- **Motivation / Decision**: align pipeline with dlt best practices and make
+  leaderboard queries reproducible.
+- **Next step**: allow Makefile to forward pytest flags like `--offline`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ It creates three tables:
 3. `. .\\.venv\\Scripts\\Activate.ps1`
 4. `pip install -r requirements.txt`
 5. `python -m src.gh_leaderboard.pipeline`
+6. Inspect results:
+
+   ```python
+   import dlt
+
+   p = dlt.pipeline("gh_leaderboard")
+   with p.sql_client() as sql:
+       print(sql.execute_sql("select * from leaderboard_daily"))
+   ```
 
 ## Quick start (Linux / macOS / WSL)
 
@@ -26,6 +35,15 @@ It creates three tables:
 3. `source .venv/bin/activate`
 4. `pip install -r requirements.txt`
 5. `python -m src.gh_leaderboard.pipeline`
+6. Inspect results:
+
+   ```python
+   import dlt
+
+   p = dlt.pipeline("gh_leaderboard")
+   with p.sql_client() as sql:
+       print(sql.execute_sql("select * from leaderboard_daily"))
+   ```
 
 Set `GITHUB_TOKEN` to raise rate limits if needed.
 
@@ -33,16 +51,28 @@ Set `GITHUB_TOKEN` to raise rate limits if needed.
 
 ```python
 from src.gh_leaderboard import pipeline
+import dlt
 
 rows = pipeline.run(
     repo="octocat/Hello-World",
     since="2012-03-06T00:00:00Z",
     until="2012-03-07T00:00:00Z",
 )
+p = dlt.pipeline(
+    "gh_leaderboard", destination="duckdb", dataset_name="gh_leaderboard"
+)
+with p.sql_client() as sql:
+    print(
+        sql.execute_sql(
+            "select * from leaderboard_daily order by author_identity"
+        )
+    )
 ```
 
 Each row has `author_identity`, `commit_day`, and `commit_count`. Use
-`offline=True` to read the bundled fixture instead of hitting GitHub.
+`offline=True` to read the bundled fixture instead of hitting GitHub. The
+results are stored in `gh_leaderboard.duckdb` with tables `commits`,
+`commits_flat`, and `leaderboard_daily`.
 
 ## Tests
 

--- a/TODO.md
+++ b/TODO.md
@@ -63,7 +63,7 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Ensure `.codex/setup.sh` creates `.venv` with lint tools (2025-08-11)
 - [x] Implement GitHub leaderboard pipeline in `src/gh_leaderboard`
 - [x] Fix markdownlint errors across docs to make `lint-docs` job pass
-- [ ] Add DuckDB destination and post-load SQL for leaderboard
+- [x] Add DuckDB destination and post-load SQL for leaderboard
 - [x] Pin `requests` dependency for HTTP calls (2025-08-11)
 - [ ] Allow `make test` to forward flags like `--offline` to pytest (2025-08-11)
-- [ ] Review dlt pipelines per `docs/dlt_guide_for_codex_2025.txt` (2025-08-11)
+- [x] Review dlt pipelines per `docs/dlt_guide_for_codex_2025.txt` (2025-08-11)

--- a/src/gh_leaderboard/post_load.sql
+++ b/src/gh_leaderboard/post_load.sql
@@ -1,0 +1,7 @@
+create or replace table leaderboard_daily as
+select
+    author_identity,
+    commit_day,
+    count(*) as commit_count
+from commits_flat
+group by author_identity, commit_day;

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import dlt
 import pytest
 
 from src.gh_leaderboard import pipeline
@@ -8,17 +9,30 @@ from src.gh_leaderboard import pipeline
 def test_pipeline_live(tmp_path: Path, offline: bool) -> None:
     if offline:
         pytest.skip("offline")
-    state = tmp_path / "state.json"
     rows = pipeline.run(
         repo="octocat/Hello-World",
         since="2012-03-06T00:00:00Z",
         until="2012-03-07T00:00:00Z",
-        state_path=state,
+        pipelines_dir=tmp_path,
     )
-    assert rows == [
+    expected = [
         {
             "author_identity": "octocat",
             "commit_day": "2012-03-06",
             "commit_count": 1,
         }
     ]
+    assert rows == expected
+    p = dlt.pipeline(
+        "gh_leaderboard",
+        destination=dlt.destinations.duckdb(str(tmp_path / "leaderboard.duckdb")),
+        dataset_name="gh_leaderboard",
+        pipelines_dir=str(tmp_path),
+    )
+    with p.sql_client() as sql:
+        result = sql.execute_sql(
+            "select author_identity, commit_day, commit_count from "
+            "leaderboard_daily order by author_identity, commit_day"
+        )
+    cols = ["author_identity", "commit_day", "commit_count"]
+    assert [dict(zip(cols, r)) for r in result] == expected


### PR DESCRIPTION
## Summary
- build GitHub commits source with incremental cursor and Link header pagination
- aggregate commits via post_load.sql into a daily leaderboard
- document DuckDB usage and test both live and offline runs

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6899f22b1dec8325b4496fe989034974