### PR TITLE
docs: add acceptance criteria for pipeline

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -129,3 +129,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: documentation
 - **Motivation / Decision**: centralise dlt practices using shared guide.
 - **Next step**: follow guide when extending dlt pipelines.
+
+## 2025-08-11  PR #15
+
+- **Summary**: Documented pipeline acceptance criteria and linked from README.
+- **Stage**: documentation
+- **Motivation / Decision**: clarify goals and close related TODO item.
+- **Next step**: add DuckDB destination and post-load SQL for leaderboard.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This project is a small [dlt](https://dlthub.com/) pipeline that loads recent
 GitHub commits into DuckDB and builds a daily leaderboard of contributors.
 
-See [docs/specs.txt](docs/specs.txt) for the master specification.
+See [docs/specs.txt](docs/specs.txt) for the master specification and
+[docs/acceptance_criteria.md](docs/acceptance_criteria.md) for goals and
+edge cases.
 
 It creates three tables:
 

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@
 
 Repeat the five‑bullet block below for every MVP feature A, B, C, …
 
-- [ ] Analyse source‑of‑truth docs; define acceptance criteria for
+- [x] Analyse source‑of‑truth docs; define acceptance criteria for
       **GitHub commits pipeline**
   - [x] Document assumptions / edge‑cases for GitHub commits pipeline in
     `/docs` or README

--- a/docs/acceptance_criteria.md
+++ b/docs/acceptance_criteria.md
@@ -1,0 +1,19 @@
+# Acceptance criteria – GitHub commits pipeline
+
+## Functional goals
+
+- Load commits from a chosen GitHub repository into DuckDB.
+- Build a daily leaderboard that counts commits per author.
+- Offer an offline mode that reads bundled fixture data.
+
+## Success conditions
+
+- All commit pages are fetched for the requested window.
+- `leaderboard_daily` reflects the commit totals per author.
+- A rerun with `--since` only processes new commits.
+
+## Edge cases
+
+- Hitting API rate limits reports a clear error and exits.
+- Missing author info falls back to email or name fields.
+- An empty time window still creates empty output tables.


### PR DESCRIPTION
## Summary
- record GitHub commits pipeline acceptance criteria in `docs`
- link the new criteria from README
- tick TODO item and log work in NOTES

## Testing
- `npx --yes markdownlint-cli README.md docs/acceptance_criteria.md NOTES.md TODO.md`
- `npx --yes markdown-link-check README.md docs/acceptance_criteria.md NOTES.md TODO.md`
- `grep -R --line-number -E '<<<<<<<|=======|>>>>>>>' --exclude-dir=.venv --exclude-dir=.git --exclude-dir=node_modules --exclude=AGENTS.md --exclude=ci.yml .`

------
https://chatgpt.com/codex/tasks/task_e_6899f25d0dd4832599f7e3f652a7362a