### PR TITLE
Allow forwarding pytest flags via Makefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.6 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.7 -->
 
 > **Read this file first** before opening a pull‑request.  
 > It defines the ground rules that keep humans, autonomous agents and CI in‑sync.  
@@ -50,10 +50,11 @@ repo and run in local IDE ()Visual Studion 2022 on Win 11) to test manually.
 2. **Pre‑commit commands** (also run by CI):  
    ```bash
    make lint                  # all format / static‑analysis steps
-   make test                  # project’s unit‑/integration tests
+   make test [PYTEST_ARGS=...]# project’s unit-/integration tests
    ```
 
    * `make test` fails when no tests are collected; ensure at least one exists.
+   * Pass flags to pytest via `PYTEST_ARGS`, e.g. `make test PYTEST_ARGS="--offline"`.
    Markdown lint rules live in `.markdownlint.json` for now.
 3. **Test collection** – `make test` must fail if no tests are collected.
 4. **Style rules** – keep code formatted (`black`, `prettier`, `dart format`, etc.) and Markdown lines ≤ 80 chars; exactly **one blank line** separates log entries.  

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 VENV?=.venv
 PYTHON=$(VENV)/bin/python
+# extra flags for pytest, e.g. make test PYTEST_ARGS="--offline"
+PYTEST_ARGS?=$(ARGS)
 
 .PHONY: lint lint-python lint-markdown test
 
@@ -13,4 +15,4 @@ lint-markdown:
 	npx --yes markdownlint-cli '**/*.md'
 
 test:
-	$(VENV)/bin/pytest
+	$(VENV)/bin/pytest $(PYTEST_ARGS)

--- a/NOTES.md
+++ b/NOTES.md
@@ -129,3 +129,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: documentation
 - **Motivation / Decision**: centralise dlt practices using shared guide.
 - **Next step**: follow guide when extending dlt pipelines.
+
+## 2025-08-11  PR #15
+
+- **Summary**: Forwarded pytest flags via `PYTEST_ARGS` and documented usage.
+- **Stage**: implementation
+- **Motivation / Decision**: allow offline runs from Makefile, closing TODO item.
+- **Next step**: revisit if more pytest options are needed.

--- a/README.md
+++ b/README.md
@@ -49,10 +49,14 @@ Each row has `author_identity`, `commit_day`, and `commit_count`. Use
 Run unit and end-to-end tests:
 
 ```bash
-pytest -q
+make test
 ```
 
-Add `--offline` to skip network tests when the environment has no internet.
+Forward extra flags with `PYTEST_ARGS`. For example, skip network tests:
+
+```bash
+make test PYTEST_ARGS="--offline"
+```
 
 ## Incremental loads
 

--- a/TODO.md
+++ b/TODO.md
@@ -65,5 +65,5 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Fix markdownlint errors across docs to make `lint-docs` job pass
 - [ ] Add DuckDB destination and post-load SQL for leaderboard
 - [x] Pin `requests` dependency for HTTP calls (2025-08-11)
-- [ ] Allow `make test` to forward flags like `--offline` to pytest (2025-08-11)
+- [x] Allow `make test` to forward flags like `--offline` to pytest (2025-08-11)
 - [ ] Review dlt pipelines per `docs/dlt_guide_for_codex_2025.txt` (2025-08-11)


### PR DESCRIPTION
## Summary
- allow make test to forward flags through PYTEST_ARGS
- document new PYTEST_ARGS usage in README and AGENTS
- tick TODO item and log update in NOTES

## Testing
- `make lint`
- `make test PYTEST_ARGS="--offline"`


------
https://chatgpt.com/codex/tasks/task_e_6899f260988c8325ac011b667b100aaf