### PR TITLE
docs: wrap lint commands in AGENTS code block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ repo and run in local IDE ()Visual Studion 2022 on Win 11) to test manually.
    * `make test` fails when no tests are collected; ensure at least one exists.
    * Pass flags to pytest via `PYTEST_ARGS`, e.g. `make test PYTEST_ARGS="--offline"`.
 
+   ```bash
    make lint                      # all format / static‑analysis steps
    pytest --cov=src --cov-fail-under=80  # unit/integration tests w/ coverage
    ```

--- a/NOTES.md
+++ b/NOTES.md
@@ -160,3 +160,8 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: align pipeline with dlt best practices and make
   leaderboard queries reproducible.
 - **Next step**: allow Makefile to forward pytest flags like `--offline`.
+
+- 2025-08-11: Wrapped lint and test commands in `AGENTS.md` with a bash code
+  block to remove a stray fence. Reason: keep contributor guide rendering clean
+  and lint instructions accurate. Decisions: prefer explicit fenced block over
+  omitting commands.

--- a/TODO.md
+++ b/TODO.md
@@ -67,3 +67,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Pin `requests` dependency for HTTP calls (2025-08-11)
 - [x] Allow `make test` to forward flags like `--offline` to pytest (2025-08-11)
 - [x] Review dlt pipelines per `docs/dlt_guide_for_codex_2025.txt` (2025-08-11)
+- [x] Wrap lint and test commands in `AGENTS.md` code fence (2025-08-11)


### PR DESCRIPTION
## Summary
- wrap `make lint` and `pytest` commands in bash fence in AGENTS.md
- log the docs fix in NOTES.md and TODO.md

## Testing
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_6899f84e879c8325a9ae60f2d442c0cc