### PR TITLE
chore: anchor conflict marker check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           npx --yes markdownlint-cli '**/*.md'
-          grep -R --line-number -E '<<<<<<<|=======|>>>>>>>' . && exit 1 || echo "No conflict markers"
+          git grep -nE '^<<<<<<< |^=======|^>>>>>>>' -- && exit 1 || echo "No conflict markers"
 
   link-check:
     needs: [changes]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.7 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.8 -->
 
 > **Read this file first** before opening a pull‑request.  
 > It defines the ground rules that keep humans, autonomous agents and CI in‑sync.  
@@ -25,7 +25,7 @@ repo and run in local IDE ()Visual Studion 2022 on Win 11) to test manually.
 | **Distinct‑files rule** | Every concurrent task **must** edit a unique list of non‑markdown files.<br>_Shared exceptions:_ anyone may **append** (never rewrite) `AGENTS.md`, `TODO.md`, `NOTES.md`. |
 | **Append‑only logs** | `TODO.md` & `NOTES.md` are linear logs—**never delete or reorder entries**.<br>Add new items **at the end of the file**. |
 | **Generated‑files rule** | Anything under `generated/**` or `openapi/**` is **code‑generated** – never hand‑edit; instead rerun the generator. |
-| **Search for conflict markers before every commit** | `git grep -n '<<<<<<<\\|=======\\|>>>>>>>'` must return nothing. |
+| **Search for conflict markers before every commit** | `git grep -nE '^<<<<<<< |^=======|^>>>>>>>' --` must return nothing. |
 
 ---
 
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           npx --yes markdownlint-cli '**/*.md'
-          grep -R --line-number -E '<<<<<<<|=======|>>>>>>>' . && exit 1 || echo "No conflict markers"
+          git grep -nE '^<<<<<<< |^=======|^>>>>>>>' -- && exit 1 || echo "No conflict markers"
 
   test:
     needs: [changes]

--- a/NOTES.md
+++ b/NOTES.md
@@ -165,3 +165,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
   block to remove a stray fence. Reason: keep contributor guide rendering clean
   and lint instructions accurate. Decisions: prefer explicit fenced block over
   omitting commands.
+
+## 2025-08-11  PR #19
+
+- **Summary**: Anchored conflict check with `git grep` and updated docs.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensure conflict markers are caught while ignoring
+  untracked files.
+- **Next step**: consider adding pre-commit hooks for conflict markers.

--- a/TODO.md
+++ b/TODO.md
@@ -68,3 +68,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Allow `make test` to forward flags like `--offline` to pytest (2025-08-11)
 - [x] Review dlt pipelines per `docs/dlt_guide_for_codex_2025.txt` (2025-08-11)
 - [x] Wrap lint and test commands in `AGENTS.md` code fence (2025-08-11)
+- [x] Replace `grep` with anchored `git grep` for conflict checks (2025-08-11)


### PR DESCRIPTION
## Summary
- use `git grep` with line anchors in docs-only CI job to catch merge markers
- bump contributor guide to v1.8 and document the new conflict check
- record change in project notes and TODO list

## Testing
- `.codex/setup.sh`
- `make lint`
- `npx markdownlint-cli '**/*.md'`
- `git grep -nE '^<<<<<<< |^=======|^>>>>>>>' -- && exit 1 || echo 'No conflict markers'`


------
https://chatgpt.com/codex/tasks/task_e_6899faf156908325ad67f523a26370b0