### PR TITLE
docs: clarify conflict marker search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.8 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.9 -->
 
 > **Read this file first** before opening a pull‑request.  
-> It defines the ground rules that keep humans, autonomous agents and CI in‑sync.  
+> It defines the ground rules that keep humans, autonomous agents and
+> CI in‑sync.
 > If you change *any* rule below, **bump the version number in this heading**.
 
 ---
@@ -10,43 +11,61 @@ Do as specified in signle source of truth (unless unable to implement).
 There are 2 sections in single source of truth (/docs/specs.txt):
 1. #Client specifications (not to be changed, read only).
 2. #Detailed specifications (may be wrong, maybe changed as last resort).
-If something is not specified in single source of truth - choose simplest safest options.
+If something is not specified in single source of truth - choose
+simplest safest options.
 Update TODO.md with what to do based on /docs/specs.txt.
 Implement project as specified in TODO.md. Reflect on progress in NOTES.md.
-When any issue in codex environment happens, always suggest additions/modifications 
-to this AGENTS.md to prevent such issues in future.
-Maintain and develop the project so that after each new feature user will be able to download github
-repo and run in local IDE ()Visual Studion 2022 on Win 11) to test manually.
+When any issue in codex environment happens, always suggest
+additions/modifications to this AGENTS.md to prevent such issues in
+future.
+Maintain and develop the project so that after each new feature user
+will be able to download github repo and run in local IDE (Visual
+Studion 2022 on Win 11) to test manually.
 
 ## 1 · File‑ownership & merge‑conflict safety
 
 | Rule | Detail |
 |------|--------|
-| **Distinct‑files rule** | Every concurrent task **must** edit a unique list of non‑markdown files.<br>_Shared exceptions:_ anyone may **append** (never rewrite) `AGENTS.md`, `TODO.md`, `NOTES.md`. |
-| **Append‑only logs** | `TODO.md` & `NOTES.md` are linear logs—**never delete or reorder entries**.<br>Add new items **at the end of the file**. |
-| **Generated‑files rule** | Anything under `generated/**` or `openapi/**` is **code‑generated** – never hand‑edit; instead rerun the generator. |
-| **Search for conflict markers before every commit** | `git grep -nE '^<<<<<<< |^=======|^>>>>>>>' --` must return nothing. |
+| **Distinct‑files rule** | Every concurrent task **must** edit a unique |
+| | list of non‑markdown files.<br>_Shared exceptions:_ anyone may |
+| | **append** (never rewrite) `AGENTS.md`, `TODO.md`, `NOTES.md`. |
+| **Append‑only logs** | `TODO.md` & `NOTES.md` are linear logs—never |
+| | delete or reorder entries.<br>Add new items at the end of the |
+| | file. |
+| **Generated‑files rule** | Anything under `generated/**` or `openapi/**` |
+| | is **code‑generated** – never hand‑edit; instead rerun the generator. |
+| **Search for conflict markers** | Run `git grep -nE '^<{7}|^={7}|^>{7}' --` |
+| | before every commit and make sure it finds nothing. |
+| | Never write the conflict markers verbatim; use `<{7}`, `={7}`, or `>{7}` |
+| | when referencing them. |
 
 ---
 
 ## 2 · Bootstrap (first‑run) checklist
 
 
-1. Run `.codex/setup.sh` (or `./setup.sh`) once after cloning & whenever dependencies change.
-   *The script creates `.venv/` and installs runtime, lint & test dependencies.*
+1. Run `.codex/setup.sh` (or `./setup.sh`) once after cloning &
+   whenever dependencies change.
+   *The script creates `.venv/` and installs runtime, lint & test
+   dependencies.*
 2. Create `.venv` (`python -m venv .venv`) and install deps:
    `.venv/bin/pip install -r requirements.txt`.
    Run `.codex/setup.sh` after activating; the Makefile uses `.venv/bin`.
-   *The script installs language tool‑chains, pins versions and injects secrets.*
-3. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …) in the repository/organisation **Secrets** console.  
-4. Verify the **secret‑detection helper step** in `.github/workflows/ci.yml` (see § 4) so forks without secrets still pass.  
+   *The script installs language tool‑chains, pins versions and
+   injects secrets.*
+3. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …) in
+   the repository/organisation **Secrets** console.
+4. Verify the **secret‑detection helper step** in
+   `.github/workflows/ci.yml` (see § 4) so forks without secrets
+   still pass.
 5. On the first PR, update README badges to point at your fork (owner/repo).
 
 ---
 
 ## 3 · What every contributor must know up‑front
 
-1. **Branch & PR flow** – fork → `feat/<topic>` → PR into `main` (one reviewer required).  
+1. **Branch & PR flow** – fork → `feat/<topic>` → PR into `main` (one
+   reviewer required).
 2. **Pre‑commit commands** (also run by CI):
    ```bash
    make lint                  # all format / static‑analysis steps
@@ -54,7 +73,8 @@ repo and run in local IDE ()Visual Studion 2022 on Win 11) to test manually.
    ```
 
    * `make test` fails when no tests are collected; ensure at least one exists.
-   * Pass flags to pytest via `PYTEST_ARGS`, e.g. `make test PYTEST_ARGS="--offline"`.
+   * Pass flags to pytest via `PYTEST_ARGS`, e.g. `make test
+     PYTEST_ARGS="--offline"`.
 
    ```bash
    make lint                      # all format / static‑analysis steps
@@ -66,12 +86,20 @@ repo and run in local IDE ()Visual Studion 2022 on Win 11) to test manually.
 
    Markdown lint rules live in `.markdownlint.json` for now.
 3. **Test collection** – `make test` must fail if no tests are collected.
-4. **Style rules** – keep code formatted (`black`, `prettier`, `dart format`, etc.) and Markdown lines ≤ 80 chars; exactly **one blank line** separates log entries.  
-5. **Exit‑code conventions** – scripts must exit ≠ 0 on failure so CI catches regressions (e.g. fail fast when quality gates or metric thresholds aren’t met).  
-6. **Version‑pin policy** – pin *major*/*minor* versions for critical runtimes & actions (e.g. `actions/checkout@v4`, `node@20`, `python~=3.11`).  
-7. **When docs change, update them everywhere** – if ambiguity arises, `/docs` overrides this file.
-8. **Log discipline** – when a TODO item is ticked you **must** add the matching
-   section in `NOTES.md` *in the same PR*; this keeps roadmap and log in‑sync.  
+4. **Style rules** – keep code formatted (`black`, `prettier`,
+   `dart format`, etc.) and Markdown lines ≤ 80 chars; exactly **one
+   blank line** separates log entries.
+5. **Exit‑code conventions** – scripts must exit ≠ 0 on failure so CI
+   catches regressions (e.g. fail fast when quality gates or metric
+   thresholds aren’t met).
+6. **Version‑pin policy** – pin *major*/*minor* versions for critical
+   runtimes & actions (e.g. `actions/checkout@v4`, `node@20`,
+   `python~=3.11`).
+7. **When docs change, update them everywhere** – if ambiguity arises,
+   `/docs` overrides this file.
+8. **Log discipline** – when a TODO item is ticked you **must** add
+   the matching section in `NOTES.md` *in the same PR*; this keeps
+   roadmap and log in‑sync.
 
 ---
 
@@ -104,8 +132,9 @@ jobs:
     outputs:
       has_pages_token: ${{ steps.echo.outputs.has_pages }}
     steps:
-      - id: echo         # returns 'true' / 'false'
-        run: echo "has_pages=${{ secrets.GH_PAGES_TOKEN != '' }}" >> $GITHUB_OUTPUT
+        - id: echo         # returns 'true' / 'false'
+          run: echo "has_pages=${{ secrets.GH_PAGES_TOKEN != '' }}" >> \
+            $GITHUB_OUTPUT
 
   lint-docs:
     needs: [changes]
@@ -115,7 +144,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           npx --yes markdownlint-cli '**/*.md'
-          git grep -nE '^<<<<<<< |^=======|^>>>>>>>' -- && exit 1 || echo "No conflict markers"
+          git grep -nE '^<{7}|^={7}|^>{7}' -- && exit 1 || \
+            echo "No conflict markers"
 
   test:
     needs: [changes]
@@ -131,7 +161,8 @@ jobs:
 
 * **Docs‑only changes** run in seconds (`lint-docs`).  
 * **Code changes** run full lint + tests (`test`).  
-* Add job matrices (multi‑language), action‑lint, or deployment later—guardrails above already catch the 90 % most common issues.  
+* Add job matrices (multi‑language), action‑lint, or deployment later—
+  guardrails above already catch the 90 % most common issues.
 
 ---
 
@@ -139,12 +170,14 @@ jobs:
 
 * 4‑space indent (or 2‑spaces for JS/TS when enforced by the linter).  
 * ≤ 20 logical LOC per function, ≤ 2 nesting levels.  
-* Surround headings / lists / fenced code with a blank line (markdownlint MD022, MD032).  
+* Surround headings / lists / fenced code with a blank line
+  (markdownlint MD022, MD032).
 * Use `1.` for every item in ordered lists (markdownlint MD029).
 * **No trailing spaces.** Run `git diff --check` or `make lint-docs`.  
 * Wrap identifiers like `__init__` in back‑ticks to avoid MD050.  
 * Each public API carries a short doc‑comment.  
-* Keep Markdown lines ≤ 80 chars to improve diff readability (tables may exceed if unavoidable).
+* Keep Markdown lines ≤ 80 chars to improve diff readability (tables
+  may exceed if unavoidable).
 
 ### 5.1 Additional instructions:
 
@@ -159,15 +192,18 @@ Clear, modular structure
 Consistent formatting
 Meaningful docstrings and comments
 dlt usage:
-Proper usage of dlt entities, such as sources, resources, transformers, etc.
+Proper usage of dlt entities, such as sources, resources, transformers,
+etc.
 Use of incremental loading
 Correct handling of pagination
 Tests:
 One well-written unit test for an individual function or small component
-One comprehensive test that runs your dlt pipeline end to end (you decide which invariants must hold and why)
+One comprehensive test that runs your dlt pipeline end to end (you
+decide which invariants must hold and why)
 Documentation:
 A README.md that explains how to set up, run, and test the project
-A short design decisions section (why this API, how you chose incremental fields, what you’d do next with more time)
+A short design decisions section (why this API, how you chose
+incremental fields, what you’d do next with more time)
 Reproducibility:
 We should be able to clone your repo and run the pipeline end to end
 Using a public API is recommended
@@ -177,7 +213,10 @@ Pin your dependencies
 
 ## 6 · How to update these rules
 
-* Edit **only what you need**, append a dated bullet in `NOTES.md`, **bump the version number** at the top of this file, and open a PR.  
-* When CI tooling changes (new Action versions, new secrets, extra language runners) **update both** this guide **and** the workflow file in the **same PR**.  
+* Edit **only what you need**, append a dated bullet in `NOTES.md`,
+  **bump the version number** at the top of this file, and open a PR.
+* When CI tooling changes (new Action versions, new secrets, extra
+  language runners) **update both** this guide **and** the workflow
+  file in the **same PR**.
 
 Happy shipping 🚀

--- a/NOTES.md
+++ b/NOTES.md
@@ -173,3 +173,12 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: ensure conflict markers are caught while ignoring
   untracked files.
 - **Next step**: consider adding pre-commit hooks for conflict markers.
+
+## 2025-08-12  PR #20
+
+- **Summary**: Clarified conflict marker checks and replaced markers with
+  placeholders in AGENTS guide.
+- **Stage**: documentation
+- **Motivation / Decision**: prevent accidental markers and guide contributors
+  to use placeholder regex.
+- **Next step**: explore a pre-commit hook for conflict checks.

--- a/TODO.md
+++ b/TODO.md
@@ -69,3 +69,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Review dlt pipelines per `docs/dlt_guide_for_codex_2025.txt` (2025-08-11)
 - [x] Wrap lint and test commands in `AGENTS.md` code fence (2025-08-11)
 - [x] Replace `grep` with anchored `git grep` for conflict checks (2025-08-11)
+- [x] Revise conflict marker guidelines using placeholders in AGENTS.md (2025-08-12)


### PR DESCRIPTION
## Summary
- replace literal conflict markers in contributor guide with safe placeholders
- warn contributors to run `git grep -nE '^<{7}|^={7}|^>{7}' --` and avoid writing markers verbatim
- update CI example snippet and bump AGENTS guide to v1.9

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ae57beb5c8325862b59ab5ac77ec6