### PR TITLE
Add pre-commit config with formatting and lint checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.4
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.9 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.10 -->
 
-> **Read this file first** before opening a pull‑request.  
+> **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and
 > CI in‑sync.
 > If you change *any* rule below, **bump the version number in this heading**.
@@ -68,8 +68,9 @@ Studion 2022 on Win 11) to test manually.
    reviewer required).
 2. **Pre‑commit commands** (also run by CI):
    ```bash
-   make lint                  # all format / static‑analysis steps
-   make test [PYTEST_ARGS=...]# project’s unit-/integration tests
+   pre-commit run --all-files   # formatters and basic checks
+   make lint                    # static analysis
+   make test [PYTEST_ARGS=...]  # unit / integration tests
    ```
 
    * `make test` fails when no tests are collected; ensure at least one exists.
@@ -159,8 +160,8 @@ jobs:
       - run: .venv/bin/pytest --cov=src --cov-fail-under=80
 ```
 
-* **Docs‑only changes** run in seconds (`lint-docs`).  
-* **Code changes** run full lint + tests (`test`).  
+* **Docs‑only changes** run in seconds (`lint-docs`).
+* **Code changes** run full lint + tests (`test`).
 * Add job matrices (multi‑language), action‑lint, or deployment later—
   guardrails above already catch the 90 % most common issues.
 
@@ -168,14 +169,14 @@ jobs:
 
 ## 5 · Coding & documentation style
 
-* 4‑space indent (or 2‑spaces for JS/TS when enforced by the linter).  
-* ≤ 20 logical LOC per function, ≤ 2 nesting levels.  
+* 4‑space indent (or 2‑spaces for JS/TS when enforced by the linter).
+* ≤ 20 logical LOC per function, ≤ 2 nesting levels.
 * Surround headings / lists / fenced code with a blank line
   (markdownlint MD022, MD032).
 * Use `1.` for every item in ordered lists (markdownlint MD029).
-* **No trailing spaces.** Run `git diff --check` or `make lint-docs`.  
-* Wrap identifiers like `__init__` in back‑ticks to avoid MD050.  
-* Each public API carries a short doc‑comment.  
+* **No trailing spaces.** Run `git diff --check` or `make lint-docs`.
+* Wrap identifiers like `__init__` in back‑ticks to avoid MD050.
+* Each public API carries a short doc‑comment.
 * Keep Markdown lines ≤ 80 chars to improve diff readability (tables
   may exceed if unavoidable).
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,7 +1,7 @@
 # Engineering log  – append entries at **the end** (oldest → newest)
 
-Each pull‑request **adds one new section** using the fixed template below.  
-*Never modify or reorder previous entries.*  
+Each pull‑request **adds one new section** using the fixed template below.
+*Never modify or reorder previous entries.*
 Keep lines ≤ 80 chars and leave exactly **one blank line** between sections.
 
 ---
@@ -182,3 +182,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: prevent accidental markers and guide contributors
   to use placeholder regex.
 - **Next step**: explore a pre-commit hook for conflict checks.
+
+## 2025-08-12  PR #21
+
+- **Summary**: Added pre-commit config with black, ruff, and basic checks.
+- **Stage**: implementation
+- **Motivation / Decision**: centralise formatting and linting to keep diffs
+  small and catch whitespace issues early.
+- **Next step**: add markdownlint and actionlint hooks.

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 
 ## 3 · Quality & automation
 
-- [ ] Add pre‑commit hooks (formatters, linters, markdownlint, actionlint)
+- [x] Add pre‑commit hooks (formatters, linters, markdownlint, actionlint)
 - [x] Enforce coverage threshold (≥ 80 % branch, exclude `/generated/**`)
 - [ ] Add linters for conflict markers, trailing spaces and NOTES ordering
 - [ ] Introduce dependabot / Renovate with the version‑pin policy from
@@ -56,7 +56,7 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 
 ---
 
-### Add new items below this line  
+### Add new items below this line
 *(append only; keep earlier history intact)*
 - [x] Add `.gitignore` for DLT state, DuckDB, venv, caches (2025-08-11)
 - [x] Require `make test` to fail when no tests are collected (2025-08-11)
@@ -70,3 +70,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Wrap lint and test commands in `AGENTS.md` code fence (2025-08-11)
 - [x] Replace `grep` with anchored `git grep` for conflict checks (2025-08-11)
 - [x] Revise conflict marker guidelines using placeholders in AGENTS.md (2025-08-12)
+- [ ] Add markdownlint and actionlint to pre-commit config (2025-08-12)

--- a/docs/dlt_guide_for_codex_2025.txt
+++ b/docs/dlt_guide_for_codex_2025.txt
@@ -3,7 +3,7 @@ DLT (DATA LOAD TOOL) — PRACTICAL GUIDE FOR OPENAI CODEX (2025)
 Author: Ivan Starostin (MD, PhD → B.Sc. SE), prepared for a dlt take‑home assignment
 Version: 2025-08-11
 
-IMPORTANT: This document describes the open‑source Python library “dlt” from dltHub (https://github.com/dlt-hub/dlt). 
+IMPORTANT: This document describes the open‑source Python library “dlt” from dltHub (https://github.com/dlt-hub/dlt).
 It is NOT Databricks “Delta Live Tables” (also called DLT). Be careful not to confuse them.
 
 -----------------------------------------------------------------------
@@ -11,13 +11,13 @@ It is NOT Databricks “Delta Live Tables” (also called DLT). Be careful not t
 -----------------------------------------------------------------------
 • What: dlt is an open-source Python library for building data loading pipelines (ELT/ETL). You write normal Python (functions or generators that yield dicts/rows), decorate them with @dlt.resource / @dlt.source, and dlt takes care of schema inference, normalization (flattening), loading, state, and retries.
 • Why: You get a simple, testable, Pythonic approach with built‑in incremental loading, pagination helpers, schema evolution, credentials/config management, and many supported destinations (DuckDB, BigQuery, Snowflake, Postgres, Redshift, ClickHouse, Databricks/DeltaLake, Synapse, Athena, etc.).
-• How: 
-  1) Define resources (data extractors) and optional transformers. 
-  2) Create a pipeline (destination + dataset_name). 
-  3) Run pipeline.run(source()) or pipeline.run(resource()). 
-  4) Incremental loading is one line via dlt.sources.incremental(...). 
+• How:
+  1) Define resources (data extractors) and optional transformers.
+  2) Create a pipeline (destination + dataset_name).
+  3) Run pipeline.run(source()) or pipeline.run(resource()).
+  4) Incremental loading is one line via dlt.sources.incremental(...).
   5) Pagination is declarative in the REST API source, or imperatively with RESTClient helpers.
-• Key APIs to remember: 
+• Key APIs to remember:
   - dlt.pipeline(pipeline_name, destination, dataset_name, …)
   - @dlt.source(...) → groups resources
   - @dlt.resource(name?, table_name?, primary_key?, write_disposition?="append|merge|replace", selected?=True, ...)
@@ -38,14 +38,14 @@ dlt (“data load tool”) is a Python library for loading data from APIs, datab
 -----------------------------------------------------------------------
 2) NOTATION AND TERMINOLOGY
 -----------------------------------------------------------------------
-• Pipeline: A configured object with destination and dataset_name that orchestrates extract → normalize → load. 
-  Create with dlt.pipeline(...). Run with pipeline.run(...). 
+• Pipeline: A configured object with destination and dataset_name that orchestrates extract → normalize → load.
+  Create with dlt.pipeline(...). Run with pipeline.run(...).
 • Source: A logical grouping of related resources (e.g., endpoints of one API). Use @dlt.source to define.
 • Resource: A Python (optionally async) function that yields items (dicts/rows). Decorate with @dlt.resource.
   Key arguments: primary_key, write_disposition (append/merge/replace), table_name, selected.
 • Transformer: A function that consumes data from one resource and yields transformed/enriched items. Use @dlt.transformer (or light‑weight add_map for item‑level transforms).
 • Incremental: Cursor‑based helper to only load new/changed rows (dlt.sources.incremental). Tracks start_value / last_value / end_value and persists state.
-• Destination: Where data lands (e.g., DuckDB, BigQuery, Snowflake, Postgres, Redshift, ClickHouse, Synapse, Athena, Databricks, vector DBs). 
+• Destination: Where data lands (e.g., DuckDB, BigQuery, Snowflake, Postgres, Redshift, ClickHouse, Synapse, Athena, Databricks, vector DBs).
 • Normalization: Flatten/unnest nested JSON, compute a relational schema, and evolve schema as the payload changes.
 • Write Disposition: How to write data into destination tables: replace (full reload), append, merge (upsert / SCD2 / delete-insert strategies).
 • State: dlt stores pipeline state (e.g., incremental cursors) and commits it together with load packages to ensure idempotency.
@@ -91,7 +91,7 @@ print(pipeline.dataset().items.df().head())  # access data via Ibis-backed datas
 -----------------------------------------------------------------------
 5) PROJECT SCAFFOLDING (CLI) AND VERIFIED SOURCES
 -----------------------------------------------------------------------
-• dlt init <source> <destination> 
+• dlt init <source> <destination>
   - Creates .dlt/config.toml and .dlt/secrets.toml, a pipeline script, and requirements.txt.
   - --list-sources and --list-destinations enumerate what’s available.
   - Re‑running dlt init in the same folder can add more sources or update them.
@@ -238,7 +238,7 @@ def posts():
 -----------------------------------------------------------------------
 10) DESTINATIONS (examples)
 -----------------------------------------------------------------------
-Core destinations include DuckDB, BigQuery, Snowflake, PostgreSQL, Redshift, ClickHouse, Synapse, Athena, Databricks/Delta Lake, MotherDuck, and more. 
+Core destinations include DuckDB, BigQuery, Snowflake, PostgreSQL, Redshift, ClickHouse, Synapse, Athena, Databricks/Delta Lake, MotherDuck, and more.
 Choose one by passing destination="duckdb" | "bigquery" | "snowflake" | "postgres" | "redshift" | "clickhouse" | "synapse" | "athena" | "databricks" | "filesystem" | etc.
 
 Switching destination typically requires adding credentials in .dlt/secrets.toml and re‑running the pipeline.
@@ -383,7 +383,7 @@ Design decisions
   - repo_events: append (immutable log, dedup via primary_key=id)
   - daily_leaderboard: replace (materialized each run from raw events)
 • Pagination: GitHub’s REST uses Link headers → LinkHeaderPaginator.
-• Rate limits: use a token; consider exponential backoff/retries (RESTClient uses requests with retry/timeout). 
+• Rate limits: use a token; consider exponential backoff/retries (RESTClient uses requests with retry/timeout).
 • Reproducibility: pin dependencies; include sample .env/.toml; provide one E2E test using fixture pages.
 
 What I’d do next with more time
@@ -396,7 +396,7 @@ What I’d do next with more time
 15) STEP 1 (ASSIGNMENT): HOW I WOULD HAVE USED dlt IN A PREVIOUS PROJECT
 -----------------------------------------------------------------------
 Context (hypothetical, clinically inspired):
-In a medical imaging QA project, we collected daily scanner logs (JSON) and RIS metadata from a PostgreSQL database, then created a tidy dataset for quality dashboards. 
+In a medical imaging QA project, we collected daily scanner logs (JSON) and RIS metadata from a PostgreSQL database, then created a tidy dataset for quality dashboards.
 
 How dlt would help:
 • Filesystem source + SQL database verified source to extract both JSON logs (flattened automatically) and RIS tables.
@@ -434,14 +434,14 @@ pipeline = dlt.pipeline(pipeline_name: str, destination: str, dataset_name: str,
 @dlt.source(max_table_nesting: int = 2, ...)
 def my_source(...): ...
 
-@dlt.resource(name?: str, table_name?: str|callable, primary_key?: str|tuple, 
+@dlt.resource(name?: str, table_name?: str|callable, primary_key?: str|tuple,
               write_disposition?: "append"|"merge"|"replace", selected?: bool = True, ...)
 def my_resource(...): yield {...}
 
 @dlt.transformer(data_from=other_resource, name?: str, write_disposition?: ...)
 def my_transformer(item): yield transformed_item
 
-inc = dlt.sources.incremental(cursor_field: str|jsonpath, initial_value?: Any, end_value?: Any, 
+inc = dlt.sources.incremental(cursor_field: str|jsonpath, initial_value?: Any, end_value?: Any,
                               row_order?: "asc"|"desc", last_value_func?: callable)
 
 # REST API declarative
@@ -496,4 +496,3 @@ dltHub. (2025). dlt GitHub repository. https://github.com/dlt-hub/dlt
 
 (Compare/contrast only to avoid confusion)
 Databricks. (2025). Lakeflow Declarative Pipelines / Delta Live Tables docs. https://docs.databricks.com/
-

--- a/docs/specs.txt
+++ b/docs/specs.txt
@@ -35,18 +35,18 @@ https://dlthub.com/docs/walkthroughs/create-a-pipeline
 #Detailed specifications (may be wrong, maybe changed as last resort):
 0) Decision summary (safe defaults)
 Source API: GitHub REST v3 — List commits.
-Use since and until to bound time windows, per_page=100, pagination via Link header. Send Accept: application/vnd.github+json and (optionally) X‑GitHub‑Api‑Version: 2022‑11‑28. 
+Use since and until to bound time windows, per_page=100, pagination via Link header. Send Accept: application/vnd.github+json and (optionally) X‑GitHub‑Api‑Version: 2022‑11‑28.
 GitHub Docs
 +1
 
-Destination: DuckDB (local file, zero external services). 
+Destination: DuckDB (local file, zero external services).
 DuckDB
 
 Scope: Single public repo (configurable), default branch only, recent time window.
 
 dlt entities: one source, one resource (commits), HeaderLinkPaginator, cursor‑based incremental, one transformer (author normalization), and one post‑load SQL step for the leaderboard.
 
-Reproducibility: pinned deps (dlt[duckdb], duckdb, pytest), .dlt/ state on disk, no cloud, works on Windows & Linux. dlt supports Python 3.9–3.14. 
+Reproducibility: pinned deps (dlt[duckdb], duckdb, pytest), .dlt/ state on disk, no cloud, works on Windows & Linux. dlt supports Python 3.9–3.14.
 dltHub
 PyPI
 
@@ -60,7 +60,7 @@ Offline (Codex/Code‑Interpreter): uses bundled fixture JSON (no HTTP).
 
 1) What the pipeline does (Input → Process → Output)
 Input
-GET /repos/{owner}/{repo}/commits?sha={branch}&since=…&until=…&per_page=100 (default branch if sha omitted). Rate‑limit: 60/h unauthenticated, 5,000/h authenticated PAT. 
+GET /repos/{owner}/{repo}/commits?sha={branch}&since=…&until=…&per_page=100 (default branch if sha omitted). Rate‑limit: 60/h unauthenticated, 5,000/h authenticated PAT.
 GitHub Docs
 +2
 GitHub Docs
@@ -68,11 +68,11 @@ GitHub Docs
 
 Process
 
-Pagination: follow Link: <…>; rel="next" until exhausted (HeaderLink paginator). 
+Pagination: follow Link: <…>; rel="next" until exhausted (HeaderLink paginator).
 GitHub Docs
 dltHub
 
-Incremental: cursor = commit.committer.date (ISO‑8601). If missing, fallback commit.author.date. Pass since on requests; dlt keeps max cursor in state to avoid re‑pulling. 
+Incremental: cursor = commit.committer.date (ISO‑8601). If missing, fallback commit.author.date. Pass since on requests; dlt keeps max cursor in state to avoid re‑pulling.
 dltHub
 
 Transform (normalize): compute:
@@ -126,7 +126,7 @@ Source: github_commits_source(repo, branch) → returns the commits resource.
 
 Resource: commits (REST client + HeaderLink paginator).
 
-Paginator: HeaderLinkPaginator (uses Link: … rel="next"; canonical for GitHub). 
+Paginator: HeaderLinkPaginator (uses Link: … rel="next"; canonical for GitHub).
 dltHub
 GitHub Docs
 
@@ -134,10 +134,10 @@ Primary key: sha (immutable commit id).
 
 Write disposition: append (commits immutable).
 
-Incremental cursor: commit.committer.date (fallback commit.author.date) passed as since on request; state kept by dlt. 
+Incremental cursor: commit.committer.date (fallback commit.author.date) passed as since on request; state kept by dlt.
 dltHub
 
-Request shaping: sha={branch}, per_page=100, since={cursor.start}, and for tests also until={end_value} to fully close the window at the source. 
+Request shaping: sha={branch}, per_page=100, since={cursor.start}, and for tests also until={end_value} to fully close the window at the source.
 GitHub Docs
 
 Transformer: flatten_commit → skinny row + stable author_identity.
@@ -151,21 +151,21 @@ Initial range: configurable; default “14 days ago → now” to keep first run
 
 Dedupe: PK=sha ensures idempotency (API overlaps possible around the cursor).
 
-Backfill option: use initial_value + end_value for a closed, historical slice (deterministic tests) without touching live incremental state. 
+Backfill option: use initial_value + end_value for a closed, historical slice (deterministic tests) without touching live incremental state.
 dltHub
 
 Ordering: do not rely on row order; pagination + cursor handle correctness.
 
 5) Pagination & rate‑limit safety
-Pagination: via Link headers (rel="next"). 
+Pagination: via Link headers (rel="next").
 GitHub Docs
 
-Rate limits: 60 req/h unauthenticated; token raises limit (5,000 req/h). Use per_page=100 + narrow windows → far below limits for one repo. 
+Rate limits: 60 req/h unauthenticated; token raises limit (5,000 req/h). Use per_page=100 + narrow windows → far below limits for one repo.
 GitHub Docs
 
 Retries: use dlt defaults (backoff); no custom logic unless needed.
 
-Headers: include Accept: application/vnd.github+json; optionally X‑GitHub‑Api‑Version: 2022‑11‑28. 
+Headers: include Accept: application/vnd.github+json; optionally X‑GitHub‑Api‑Version: 2022‑11‑28.
 GitHub Docs
 
 6) Tests (invariants; one unit + one end‑to‑end)
@@ -187,7 +187,7 @@ leaderboard_daily exists; all commit_day within the window; each commit_count �
 
 Idempotency: immediate re‑run without changing state → row counts do not decrease; sha distinctness holds.
 
-Codex/Code‑Interpreter demo: run the same E2E against the bundled fixture (fixtures/commits_sample.json) to exercise transform + load + SQL without HTTP (sandbox has no outbound network). 
+Codex/Code‑Interpreter demo: run the same E2E against the bundled fixture (fixtures/commits_sample.json) to exercise transform + load + SQL without HTTP (sandbox has no outbound network).
 OpenAI Help Center
 
 7) Repository layout
@@ -342,4 +342,3 @@ Optional: CREATE VIEW leaderboard_latest AS … WHERE commit_day >= current_date
 Do not commit .dlt/secrets.toml.
 
 Add .gitignore: .dlt/state*, *.duckdb, .venv, __pycache__/, .pytest_cache/.
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pytest==8.4.1
 pytest-cov==6.2.1
 black==24.4.2
 ruff==0.5.4
+pre-commit==3.8.0
 requests==2.32.4
-


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with Black, Ruff and basic sanity hooks
- document `pre-commit run --all-files` in contributor guide and pin dependency
- trim stray whitespace in existing docs so the hooks pass

## Testing
- `.codex/setup.sh`
- `.venv/bin/pre-commit run --all-files`
- `make lint`
- `make test PYTEST_ARGS="--offline"`


------
https://chatgpt.com/codex/tasks/task_e_689aeb678fb48325a960ac9a1bc719b4