### PR TITLE
Use pre-commit for Python linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.4
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ PYTEST_ARGS?=$(ARGS)
 lint: lint-python lint-markdown
 
 lint-python:
-	$(VENV)/bin/black .
-	$(VENV)/bin/ruff check .
+	$(VENV)/bin/pre-commit run --files $(shell git ls-files '*.py')
 
 lint-markdown:
 	npx --yes markdownlint-cli '**/*.md'

--- a/NOTES.md
+++ b/NOTES.md
@@ -182,3 +182,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: prevent accidental markers and guide contributors
   to use placeholder regex.
 - **Next step**: explore a pre-commit hook for conflict checks.
+
+## 2025-08-12  PR #21
+
+- **Summary**: Routed Python linting through pre-commit and added its config.
+- **Stage**: maintenance
+- **Motivation / Decision**: unify black and ruff under pre-commit to match
+  CI tooling.
+- **Next step**: add markdownlint and actionlint to pre-commit.

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 
 ## 3 · Quality & automation
 
-- [ ] Add pre‑commit hooks (formatters, linters, markdownlint, actionlint)
+- [x] Add pre‑commit hooks for formatters and linters (2025-08-12)
 - [x] Enforce coverage threshold (≥ 80 % branch, exclude `/generated/**`)
 - [ ] Add linters for conflict markers, trailing spaces and NOTES ordering
 - [ ] Introduce dependabot / Renovate with the version‑pin policy from
@@ -70,3 +70,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Wrap lint and test commands in `AGENTS.md` code fence (2025-08-11)
 - [x] Replace `grep` with anchored `git grep` for conflict checks (2025-08-11)
 - [x] Revise conflict marker guidelines using placeholders in AGENTS.md (2025-08-12)
+- [ ] Integrate markdownlint and actionlint pre-commit hooks (2025-08-12)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ pytest==8.4.1
 pytest-cov==6.2.1
 black==24.4.2
 ruff==0.5.4
+pre-commit==3.7.1
 requests==2.32.4
 


### PR DESCRIPTION
## Summary
- run black and ruff through `pre-commit` via `make lint`
- keep markdown linting isolated in a `lint-markdown` target
- document pre-commit adoption in TODO/NOTES

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689aeb6f9d688325857189daccfa990f