### PR TITLE
chore: add pre-commit dependency

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -9,4 +9,9 @@ fi
 
 "${REPO_ROOT}/.venv/bin/pip" install -r "${REPO_ROOT}/requirements.txt"
 
+# install git hooks when configuration is present
+if [ -f "${REPO_ROOT}/.pre-commit-config.yaml" ]; then
+    "${REPO_ROOT}/.venv/bin/pre-commit" install
+fi
+
 exit 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.9 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.10 -->
 
-> **Read this file first** before opening a pull‑request.  
+> **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and
 > CI in‑sync.
 > If you change *any* rule below, **bump the version number in this heading**.
@@ -46,8 +46,9 @@ Studion 2022 on Win 11) to test manually.
 
 1. Run `.codex/setup.sh` (or `./setup.sh`) once after cloning &
    whenever dependencies change.
-   *The script creates `.venv/` and installs runtime, lint & test
-   dependencies.*
+   *The script creates `.venv/`, installs runtime, lint & test
+   dependencies, and installs git hooks when `.pre-commit-config.yaml`
+   is present.*
 2. Create `.venv` (`python -m venv .venv`) and install deps:
    `.venv/bin/pip install -r requirements.txt`.
    Run `.codex/setup.sh` after activating; the Makefile uses `.venv/bin`.
@@ -159,8 +160,8 @@ jobs:
       - run: .venv/bin/pytest --cov=src --cov-fail-under=80
 ```
 
-* **Docs‑only changes** run in seconds (`lint-docs`).  
-* **Code changes** run full lint + tests (`test`).  
+* **Docs‑only changes** run in seconds (`lint-docs`).
+* **Code changes** run full lint + tests (`test`).
 * Add job matrices (multi‑language), action‑lint, or deployment later—
   guardrails above already catch the 90 % most common issues.
 
@@ -168,14 +169,14 @@ jobs:
 
 ## 5 · Coding & documentation style
 
-* 4‑space indent (or 2‑spaces for JS/TS when enforced by the linter).  
-* ≤ 20 logical LOC per function, ≤ 2 nesting levels.  
+* 4‑space indent (or 2‑spaces for JS/TS when enforced by the linter).
+* ≤ 20 logical LOC per function, ≤ 2 nesting levels.
 * Surround headings / lists / fenced code with a blank line
   (markdownlint MD022, MD032).
 * Use `1.` for every item in ordered lists (markdownlint MD029).
-* **No trailing spaces.** Run `git diff --check` or `make lint-docs`.  
-* Wrap identifiers like `__init__` in back‑ticks to avoid MD050.  
-* Each public API carries a short doc‑comment.  
+* **No trailing spaces.** Run `git diff --check` or `make lint-docs`.
+* Wrap identifiers like `__init__` in back‑ticks to avoid MD050.
+* Each public API carries a short doc‑comment.
 * Keep Markdown lines ≤ 80 chars to improve diff readability (tables
   may exceed if unavoidable).
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,7 +1,7 @@
 # Engineering log  – append entries at **the end** (oldest → newest)
 
-Each pull‑request **adds one new section** using the fixed template below.  
-*Never modify or reorder previous entries.*  
+Each pull‑request **adds one new section** using the fixed template below.
+*Never modify or reorder previous entries.*
 Keep lines ≤ 80 chars and leave exactly **one blank line** between sections.
 
 ---
@@ -182,3 +182,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: prevent accidental markers and guide contributors
   to use placeholder regex.
 - **Next step**: explore a pre-commit hook for conflict checks.
+
+## 2025-08-12  PR #21
+
+- **Summary**: Added pre-commit dependency and optional hook install in setup.
+- **Stage**: maintenance
+- **Motivation / Decision**: prepare repository for git hooks to catch issues
+  early.
+- **Next step**: extend pre-commit hooks with formatters and linters.

--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 
 ---
 
-### Add new items below this line  
+### Add new items below this line
 *(append only; keep earlier history intact)*
 - [x] Add `.gitignore` for DLT state, DuckDB, venv, caches (2025-08-11)
 - [x] Require `make test` to fail when no tests are collected (2025-08-11)
@@ -70,3 +70,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Wrap lint and test commands in `AGENTS.md` code fence (2025-08-11)
 - [x] Replace `grep` with anchored `git grep` for conflict checks (2025-08-11)
 - [x] Revise conflict marker guidelines using placeholders in AGENTS.md (2025-08-12)
+- [x] Pin `pre-commit` dependency and bootstrap hook install (2025-08-12)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pytest==8.4.1
 pytest-cov==6.2.1
 black==24.4.2
 ruff==0.5.4
+pre-commit==4.3.0
 requests==2.32.4
-


### PR DESCRIPTION
## Summary
- pin `pre-commit` and configure basic hooks
- install hooks from setup script and document workflow
- log dependency addition in NOTES and TODO

## Testing
- `./.codex/setup.sh`
- `pre-commit install`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689aeb69212883258dcce3012354182f