### PR TITLE
Use pre-commit for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Bootstrap
         run: ./.codex/setup.sh   # idempotent; safe when absent
-      - run: make lint
+      - run: .venv/bin/pre-commit run --all-files
       - run: .venv/bin/pytest --cov=src --cov-fail-under=80

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.10 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.11 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and
@@ -69,7 +69,6 @@ Studion 2022 on Win 11) to test manually.
 2. **Pre‑commit commands** (also run by CI):
    ```bash
    pre-commit run --all-files   # formatters and basic checks
-   make lint                    # static analysis
    make test [PYTEST_ARGS=...]  # unit / integration tests
    ```
 
@@ -78,8 +77,8 @@ Studion 2022 on Win 11) to test manually.
      PYTEST_ARGS="--offline"`.
 
    ```bash
-   make lint                      # all format / static‑analysis steps
-   pytest --cov=src --cov-fail-under=80  # unit/integration tests w/ coverage
+   pre-commit run --all-files
+   .venv/bin/pytest --cov=src --cov-fail-under=80
    ```
 
    * Coverage excludes `tests/**` and `generated/**` via `.coveragerc`.
@@ -156,7 +155,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Bootstrap
         run: ./.codex/setup.sh   # idempotent; safe when absent
-      - run: make lint
+      - run: .venv/bin/pre-commit run --all-files
       - run: .venv/bin/pytest --cov=src --cov-fail-under=80
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,10 @@ PYTHON=$(VENV)/bin/python
 # extra flags for pytest, e.g. make test PYTEST_ARGS="--offline"
 PYTEST_ARGS?=$(ARGS)
 
-.PHONY: lint lint-python lint-markdown test
+.PHONY: lint lint-markdown test
 
-lint: lint-python lint-markdown
-
-lint-python:
-	$(VENV)/bin/black .
-	$(VENV)/bin/ruff check .
+lint: lint-markdown
+	$(VENV)/bin/pre-commit run --all-files
 
 lint-markdown:
 	npx --yes markdownlint-cli '**/*.md'

--- a/NOTES.md
+++ b/NOTES.md
@@ -190,3 +190,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: centralise formatting and linting to keep diffs
   small and catch whitespace issues early.
 - **Next step**: add markdownlint and actionlint hooks.
+
+## 2025-08-12  PR #22
+
+- **Summary**: Linting now runs `pre-commit run --all-files` in Makefile and CI.
+- **Stage**: maintenance
+- **Motivation / Decision**: ensure all hooks run consistently across local
+  and CI environments.
+- **Next step**: extend pre-commit config with markdownlint and actionlint.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Each row has `author_identity`, `commit_day`, and `commit_count`. Use
 results are stored in `gh_leaderboard.duckdb` with tables `commits`,
 `commits_flat`, and `leaderboard_daily`.
 
+## Linting
+
+Run all pre-commit hooks before committing:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Tests
 
 Run unit and end-to-end tests:

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO – Road‑map  (last updated: 2025-08-11)
+# TODO – Road‑map  (last updated: 2025-08-12)
 
 > *Record only high‑level milestones here; break micro‑tasks out into Issues.*
 > **When you finish a task, tick it and append a short NOTE entry
@@ -71,3 +71,5 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Replace `grep` with anchored `git grep` for conflict checks (2025-08-11)
 - [x] Revise conflict marker guidelines using placeholders in AGENTS.md (2025-08-12)
 - [ ] Add markdownlint and actionlint to pre-commit config (2025-08-12)
+- [x] Run pre-commit hooks via `pre-commit run --all-files` in Makefile and CI
+      (2025-08-12)


### PR DESCRIPTION
## Summary
- run `pre-commit run --all-files` in Makefile instead of calling black and ruff directly
- CI test job now runs `pre-commit run --all-files`
- docs and logs mention pre-commit

## Testing
- `.venv/bin/pre-commit run --all-files`
- `npx --yes markdownlint-cli "**/*.md"`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689af1ef49a48325b546560856b25897