### PR TITLE
Add merge conflict check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,4 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+      - id: check-merge-conflict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.11 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.12 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and
@@ -34,8 +34,9 @@ Studion 2022 on Win 11) to test manually.
 | | file. |
 | **Generated‑files rule** | Anything under `generated/**` or `openapi/**` |
 | | is **code‑generated** – never hand‑edit; instead rerun the generator. |
-| **Search for conflict markers** | Run `git grep -nE '^<{7}|^={7}|^>{7}' --` |
-| | before every commit and make sure it finds nothing. |
+| **Search for conflict markers** | Run `git grep -nE '^<{7}|^={7}|^>{7}' --` before |
+| | every commit.<br>Pre-commit's `check-merge-conflict` hook also fails when |
+| | markers slip in. |
 | | Never write the conflict markers verbatim; use `<{7}`, `={7}`, or `>{7}` |
 | | when referencing them. |
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -198,3 +198,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: ensure all hooks run consistently across local
   and CI environments.
 - **Next step**: extend pre-commit config with markdownlint and actionlint.
+
+## 2025-08-12  PR #23
+
+- **Summary**: Added merge-conflict check to pre-commit and updated guides.
+- **Stage**: maintenance
+- **Motivation / Decision**: catch conflict markers early with
+  `check-merge-conflict` hook.
+- **Next step**: monitor and extend hooks like markdownlint next.

--- a/TODO.md
+++ b/TODO.md
@@ -73,3 +73,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [ ] Add markdownlint and actionlint to pre-commit config (2025-08-12)
 - [x] Run pre-commit hooks via `pre-commit run --all-files` in Makefile and CI
       (2025-08-12)
+- [x] Add `check-merge-conflict` hook to pre-commit config (2025-08-12)


### PR DESCRIPTION
## Summary
- ensure pre-commit fails when merge markers slip in
- document merge-conflict guard in contributor guide

## Testing
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_e_689af5ae90fc8325879119d3fe06e9a0