### PR TITLE
test: cover flatten_commit missing date

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -206,3 +206,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: catch conflict markers early with
   `check-merge-conflict` hook.
 - **Next step**: monitor and extend hooks like markdownlint next.
+
+## 2025-08-12  PR #24
+
+- **Summary**: Added unit tests for `flatten_commit` covering missing dates.
+- **Stage**: testing
+- **Motivation / Decision**: ensure commits without timestamps return `None`.
+- **Next step**: broaden commit test scenarios.

--- a/TODO.md
+++ b/TODO.md
@@ -74,3 +74,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Run pre-commit hooks via `pre-commit run --all-files` in Makefile and CI
       (2025-08-12)
 - [x] Add `check-merge-conflict` hook to pre-commit config (2025-08-12)
+- [x] Add tests for `flatten_commit` missing commit date (2025-08-12)

--- a/tests/test_flatten_commit.py
+++ b/tests/test_flatten_commit.py
@@ -1,0 +1,44 @@
+import pytest
+
+from src.gh_leaderboard.pipeline import flatten_commit
+
+
+@pytest.fixture
+def normal_commit() -> dict:
+    return {
+        "sha": "1",
+        "author": {"login": "alice"},
+        "commit": {
+            "author": {
+                "name": "Alice",
+                "email": "alice@example.com",
+                "date": "2024-01-01T10:00:00Z",
+            },
+            "committer": {"date": "2024-01-01T10:00:00Z"},
+        },
+    }
+
+
+@pytest.fixture
+def commit_missing_date() -> dict:
+    return {
+        "sha": "no-date",
+        "author": {"login": "alice"},
+        "commit": {
+            "author": {"name": "Alice", "email": "alice@example.com"},
+            "committer": {},
+        },
+    }
+
+
+def test_flatten_commit_normal(normal_commit: dict) -> None:
+    assert flatten_commit(normal_commit) == {
+        "sha": "1",
+        "author_identity": "alice",
+        "commit_timestamp": "2024-01-01T10:00:00Z",
+        "commit_day": "2024-01-01",
+    }
+
+
+def test_flatten_commit_missing_date(commit_missing_date: dict) -> None:
+    assert flatten_commit(commit_missing_date) is None


### PR DESCRIPTION
## Summary
- add unit tests for `flatten_commit` with normal and missing-date commits
- record work in NOTES and roadmap in TODO

## Testing
- `.codex/setup.sh`
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_e_689af96ff35483259c0efe09f9e5735c