### PR TITLE
Test GitHub commits source header and params

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -206,3 +206,12 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: catch conflict markers early with
   `check-merge-conflict` hook.
 - **Next step**: monitor and extend hooks like markdownlint next.
+
+## 2025-08-12  PR #24
+
+- **Summary**: Added tests for GitHub commits source verifying headers and
+  query parameters.
+- **Stage**: testing
+- **Motivation / Decision**: ensure token and incremental arguments reach the
+  REST client; used monkeypatch with a stub for safety.
+- **Next step**: add markdownlint and actionlint hooks.

--- a/TODO.md
+++ b/TODO.md
@@ -74,3 +74,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Run pre-commit hooks via `pre-commit run --all-files` in Makefile and CI
       (2025-08-12)
 - [x] Add `check-merge-conflict` hook to pre-commit config (2025-08-12)
+- [x] Add tests for GitHub commits source headers and params (2025-08-12)

--- a/tests/test_github_commits_source.py
+++ b/tests/test_github_commits_source.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict
+
+import pytest
+
+from src.gh_leaderboard import pipeline
+from src.gh_leaderboard.pipeline import github_commits_source
+
+
+class StubRESTClient:
+    last_instance: "StubRESTClient | None" = None
+
+    def __init__(self, base_url: str, headers: Dict[str, Any]) -> None:
+        self.base_url = base_url
+        self.headers = headers
+        self.params: Dict[str, Any] = {}
+        StubRESTClient.last_instance = self
+
+    def paginate(self, path: str, params: Dict[str, Any], paginator: Any):
+        self.path = path
+        self.params = params
+        yield []
+
+
+class Cursor:
+    def __init__(
+        self,
+        last_value: str | None = None,
+        initial_value: str | None = None,
+    ) -> None:
+        self.last_value = last_value
+        self.initial_value = initial_value
+
+
+@pytest.fixture
+def rest_client(monkeypatch: pytest.MonkeyPatch) -> type[StubRESTClient]:
+    monkeypatch.setattr(pipeline, "RESTClient", StubRESTClient)
+    return StubRESTClient
+
+
+def test_authorization_header(
+    monkeypatch: pytest.MonkeyPatch, rest_client: type[StubRESTClient]
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "t0k3n")
+    github_commits_source()
+    assert rest_client.last_instance.headers["Authorization"] == "Bearer t0k3n"
+
+
+def test_sha_and_until_params(rest_client: type[StubRESTClient]) -> None:
+    source = github_commits_source(branch="main", until="2024-01-01")
+    commits = source.resources["commits"]
+    list(commits())
+    params = rest_client.last_instance.params
+    assert params["sha"] == "main"
+    assert params["until"] == "2024-01-01"
+
+
+def test_incremental_adds_since(rest_client: type[StubRESTClient]) -> None:
+    source = github_commits_source(since="2024-01-01")
+    commits = source.resources["commits"]
+    list(commits())
+    assert rest_client.last_instance.params["since"] == "2024-01-01"


### PR DESCRIPTION
## Summary
- add tests for github commits source ensuring auth header, branch, and incremental parameters reach REST client
- record notes and TODO entry

## Testing
- `.codex/setup.sh`
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_e_689af97261d88325b2d8c0c167bc5350