### PR TITLE
Add offline run edge case tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -206,3 +206,11 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Motivation / Decision**: catch conflict markers early with
   `check-merge-conflict` hook.
 - **Next step**: monitor and extend hooks like markdownlint next.
+
+## 2025-08-12  PR #24
+
+- **Summary**: Added tests for offline edge cases and handled empty data.
+- **Stage**: testing
+- **Motivation / Decision**: Ensure pipeline handles missing dates and
+  empty fixtures.
+- **Next step**: watch for further edge cases.

--- a/TODO.md
+++ b/TODO.md
@@ -74,3 +74,6 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Run pre-commit hooks via `pre-commit run --all-files` in Makefile and CI
       (2025-08-12)
 - [x] Add `check-merge-conflict` hook to pre-commit config (2025-08-12)
+
+- [x] Add tests for offline edge cases and handle empty commit fixtures
+      (2025-08-12)

--- a/tests/test_run_edge_cases.py
+++ b/tests/test_run_edge_cases.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import json
+
+from src.gh_leaderboard import pipeline
+
+
+def test_offline_default_fixture(tmp_path: Path) -> None:
+    fixture_src = Path(__file__).parent / "fixtures" / "commits.json"
+    target = Path(pipeline.__file__).with_name("commits_fixture.json")
+    target.write_text(
+        fixture_src.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    try:
+        rows = pipeline.run(offline=True, pipelines_dir=tmp_path)
+    finally:
+        if target.exists():
+            target.unlink()
+    assert rows == [
+        {
+            "author_identity": "alice",
+            "commit_day": "2024-01-01",
+            "commit_count": 2,
+        },
+        {
+            "author_identity": "bob",
+            "commit_day": "2024-01-02",
+            "commit_count": 1,
+        },
+    ]
+
+
+def test_missing_commit_dates(tmp_path: Path) -> None:
+    fixture = [{"sha": "1", "commit": {"author": {"name": "A"}}}]
+    path = tmp_path / "missing_dates.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    rows = pipeline.run(
+        offline=True, fixture_path=path, pipelines_dir=tmp_path
+    )
+    assert rows == []
+
+
+def test_no_commits(tmp_path: Path) -> None:
+    path = tmp_path / "empty.json"
+    path.write_text("[]", encoding="utf-8")
+    rows = pipeline.run(
+        offline=True, fixture_path=path, pipelines_dir=tmp_path
+    )
+    assert rows == []


### PR DESCRIPTION
## Summary
- add coverage for default fixture, missing dates, and empty commit fixtures
- guard pipeline against empty offline data and mark network code as no-cover
- document edge-case tests in NOTES and TODO

## Testing
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=80 --offline`


------
https://chatgpt.com/codex/tasks/task_e_689af9756c4483258cbf153c8d01166b