### PR TITLE
test: ensure default duckdb path

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -245,3 +245,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: testing
 - **Motivation / Decision**: ensure commits without timestamps return `None`.
 - **Next step**: broaden commit test scenarios.
+
+## 2025-08-12  PR #29
+
+- **Summary**: Added test ensuring pipeline writes DuckDB to CWD when `pipelines_dir` is omitted.
+- **Stage**: testing
+- **Motivation / Decision**: verify default path behavior to avoid polluting repo root.
+- **Next step**: add online test for default path handling.

--- a/TODO.md
+++ b/TODO.md
@@ -80,3 +80,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [ ] Audit tests to ensure network calls are mocked or use offline fixtures (2025-08-12)
 - [ ] Audit other normalization helpers for whitespace handling (2025-08-12)
 - [x] Add tests for `flatten_commit` missing commit date (2025-08-12)
+- [x] Add test for pipeline default DuckDB path when `pipelines_dir` is omitted (2025-08-12)

--- a/tests/test_run_default_path.py
+++ b/tests/test_run_default_path.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import os
+
+from src.gh_leaderboard import pipeline
+
+
+def test_run_default_path(tmp_path: Path) -> None:
+    fixture = Path(__file__).parent / "fixtures" / "commits.json"
+    prev_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        rows = pipeline.run(offline=True, fixture_path=fixture)
+    finally:
+        os.chdir(prev_cwd)
+    assert (tmp_path / "leaderboard.duckdb").exists()
+    assert rows == [
+        {
+            "author_identity": "alice",
+            "commit_day": "2024-01-01",
+            "commit_count": 2,
+        },
+        {
+            "author_identity": "bob",
+            "commit_day": "2024-01-02",
+            "commit_count": 1,
+        },
+    ]

--- a/tests/test_run_edge_cases.py
+++ b/tests/test_run_edge_cases.py
@@ -7,9 +7,7 @@ from src.gh_leaderboard import pipeline
 def test_offline_default_fixture(tmp_path: Path) -> None:
     fixture_src = Path(__file__).parent / "fixtures" / "commits.json"
     target = Path(pipeline.__file__).with_name("commits_fixture.json")
-    target.write_text(
-        fixture_src.read_text(encoding="utf-8"), encoding="utf-8"
-    )
+    target.write_text(fixture_src.read_text(encoding="utf-8"), encoding="utf-8")
     try:
         rows = pipeline.run(offline=True, pipelines_dir=tmp_path)
     finally:
@@ -33,16 +31,12 @@ def test_missing_commit_dates(tmp_path: Path) -> None:
     fixture = [{"sha": "1", "commit": {"author": {"name": "A"}}}]
     path = tmp_path / "missing_dates.json"
     path.write_text(json.dumps(fixture), encoding="utf-8")
-    rows = pipeline.run(
-        offline=True, fixture_path=path, pipelines_dir=tmp_path
-    )
+    rows = pipeline.run(offline=True, fixture_path=path, pipelines_dir=tmp_path)
     assert rows == []
 
 
 def test_no_commits(tmp_path: Path) -> None:
     path = tmp_path / "empty.json"
     path.write_text("[]", encoding="utf-8")
-    rows = pipeline.run(
-        offline=True, fixture_path=path, pipelines_dir=tmp_path
-    )
+    rows = pipeline.run(offline=True, fixture_path=path, pipelines_dir=tmp_path)
     assert rows == []


### PR DESCRIPTION
## Summary
- test pipeline.run writes DuckDB to CWD when `pipelines_dir` is not set
- tidy existing edge-case test formatting for linting
- log new test in NOTES and TODO

## Testing
- `./.codex/setup.sh`
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689afe0ba85c8325bf28ca8dbc930595