### PR TITLE
test: cover commit login and missing key cases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.13 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.14 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and
@@ -54,6 +54,7 @@ Studion 2022 on Win 11) to test manually.
    Run `.codex/setup.sh` after activating; the Makefile uses `.venv/bin`.
    *The script installs language tool‑chains, pins versions and
    injects secrets.*
+   Ensure the `python` command is available (alias to Python 3 if needed).
 3. Export **required secrets** (`GIT_TOKEN`, `GH_PAGES_TOKEN`, …) in
    the repository/organisation **Secrets** console.
 4. Verify the **secret‑detection helper step** in

--- a/NOTES.md
+++ b/NOTES.md
@@ -245,3 +245,12 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: testing
 - **Motivation / Decision**: ensure commits without timestamps return `None`.
 - **Next step**: broaden commit test scenarios.
+
+## 2025-08-12  PR #29
+
+- **Summary**: Extended `flatten_commit` tests and noted `python` alias
+  requirement in `AGENTS.md`.
+- **Stage**: testing
+- **Motivation / Decision**: verify author fallback to email, handle malformed
+  commits, and avoid setup failures when only `python3` exists.
+- **Next step**: audit tests for other commit variants.

--- a/TODO.md
+++ b/TODO.md
@@ -80,3 +80,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [ ] Audit tests to ensure network calls are mocked or use offline fixtures (2025-08-12)
 - [ ] Audit other normalization helpers for whitespace handling (2025-08-12)
 - [x] Add tests for `flatten_commit` missing commit date (2025-08-12)
+- [x] Extend `flatten_commit` tests for missing login and commit key (2025-08-12)

--- a/tests/test_flatten_commit.py
+++ b/tests/test_flatten_commit.py
@@ -31,6 +31,27 @@ def commit_missing_date() -> dict:
     }
 
 
+@pytest.fixture
+def commit_missing_login() -> dict:
+    return {
+        "sha": "no-login",
+        "author": None,
+        "commit": {
+            "author": {
+                "name": "Bob",
+                "email": "bob@example.com",
+                "date": "2024-01-02T10:00:00Z",
+            },
+            "committer": {"date": "2024-01-02T10:00:00Z"},
+        },
+    }
+
+
+@pytest.fixture
+def commit_missing_commit_key() -> dict:
+    return {"sha": "no-commit", "author": {"login": "alice"}}
+
+
 def test_flatten_commit_normal(normal_commit: dict) -> None:
     assert flatten_commit(normal_commit) == {
         "sha": "1",
@@ -42,3 +63,18 @@ def test_flatten_commit_normal(normal_commit: dict) -> None:
 
 def test_flatten_commit_missing_date(commit_missing_date: dict) -> None:
     assert flatten_commit(commit_missing_date) is None
+
+
+def test_flatten_commit_missing_login(commit_missing_login: dict) -> None:
+    assert flatten_commit(commit_missing_login) == {
+        "sha": "no-login",
+        "author_identity": "bob",
+        "commit_timestamp": "2024-01-02T10:00:00Z",
+        "commit_day": "2024-01-02",
+    }
+
+
+def test_flatten_commit_missing_commit_key(
+    commit_missing_commit_key: dict,
+) -> None:
+    assert flatten_commit(commit_missing_commit_key) is None

--- a/tests/test_run_edge_cases.py
+++ b/tests/test_run_edge_cases.py
@@ -7,9 +7,7 @@ from src.gh_leaderboard import pipeline
 def test_offline_default_fixture(tmp_path: Path) -> None:
     fixture_src = Path(__file__).parent / "fixtures" / "commits.json"
     target = Path(pipeline.__file__).with_name("commits_fixture.json")
-    target.write_text(
-        fixture_src.read_text(encoding="utf-8"), encoding="utf-8"
-    )
+    target.write_text(fixture_src.read_text(encoding="utf-8"), encoding="utf-8")
     try:
         rows = pipeline.run(offline=True, pipelines_dir=tmp_path)
     finally:
@@ -33,16 +31,12 @@ def test_missing_commit_dates(tmp_path: Path) -> None:
     fixture = [{"sha": "1", "commit": {"author": {"name": "A"}}}]
     path = tmp_path / "missing_dates.json"
     path.write_text(json.dumps(fixture), encoding="utf-8")
-    rows = pipeline.run(
-        offline=True, fixture_path=path, pipelines_dir=tmp_path
-    )
+    rows = pipeline.run(offline=True, fixture_path=path, pipelines_dir=tmp_path)
     assert rows == []
 
 
 def test_no_commits(tmp_path: Path) -> None:
     path = tmp_path / "empty.json"
     path.write_text("[]", encoding="utf-8")
-    rows = pipeline.run(
-        offline=True, fixture_path=path, pipelines_dir=tmp_path
-    )
+    rows = pipeline.run(offline=True, fixture_path=path, pipelines_dir=tmp_path)
     assert rows == []


### PR DESCRIPTION
## Summary
- test flatten_commit without author login uses email
- test flatten_commit returns none when commit key missing
- document need for python alias in AGENTS

## Testing
- `.codex/setup.sh`
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689afe0825948325ac64a24e384d12e1