### PR TITLE
test: verify cursor uses last value

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -245,3 +245,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: testing
 - **Motivation / Decision**: ensure commits without timestamps return `None`.
 - **Next step**: broaden commit test scenarios.
+
+## 2025-08-12  PR #29
+
+- **Summary**: Added test ensuring cursor last_value is used, auth header omitted without token, and `HeaderLinkPaginator` is invoked.
+- **Stage**: testing
+- **Motivation / Decision**: verify incremental state and header handling for commit source using a stub REST client.
+- **Next step**: continue auditing tests for network mocking.

--- a/TODO.md
+++ b/TODO.md
@@ -80,3 +80,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [ ] Audit tests to ensure network calls are mocked or use offline fixtures (2025-08-12)
 - [ ] Audit other normalization helpers for whitespace handling (2025-08-12)
 - [x] Add tests for `flatten_commit` missing commit date (2025-08-12)
+- [x] Test incremental cursor uses last_value and omits auth header when token missing (2025-08-12)

--- a/tests/test_github_commits_source_cursor.py
+++ b/tests/test_github_commits_source_cursor.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict
+
+import pytest
+
+from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
+from src.gh_leaderboard import pipeline
+from src.gh_leaderboard.pipeline import github_commits_source
+
+
+class StubRESTClient:
+    last_instance: "StubRESTClient | None" = None
+
+    def __init__(self, base_url: str, headers: Dict[str, Any]) -> None:
+        self.base_url = base_url
+        self.headers = headers
+        self.params: Dict[str, Any] = {}
+        self.paginator: Any | None = None
+        StubRESTClient.last_instance = self
+
+    def paginate(self, path: str, params: Dict[str, Any], paginator: Any):
+        self.params = params
+        self.paginator = paginator
+        yield []
+
+
+def test_cursor_last_value_and_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    original_incremental = pipeline.dlt.sources.incremental
+
+    IncrementalCls = original_incremental("cursor").__class__
+
+    class FakeIncremental(IncrementalCls):
+        @property
+        def last_value(self) -> str:  # type: ignore[override]
+            return "2024-02-02T00:00:00Z"
+
+    def fake_incremental(*args: Any, **kwargs: Any) -> FakeIncremental:
+        return FakeIncremental(*args, **kwargs)
+
+    monkeypatch.setattr(pipeline.dlt.sources, "incremental", fake_incremental)
+    monkeypatch.setattr(pipeline, "RESTClient", StubRESTClient)
+
+    source = github_commits_source()
+    commits = source.resources["commits"]
+    list(commits())
+    rest = StubRESTClient.last_instance
+    assert rest is not None
+    assert rest.params["since"] == "2024-02-02T00:00:00Z"
+    assert "Authorization" not in rest.headers
+    assert isinstance(rest.paginator, HeaderLinkPaginator)

--- a/tests/test_run_edge_cases.py
+++ b/tests/test_run_edge_cases.py
@@ -7,9 +7,7 @@ from src.gh_leaderboard import pipeline
 def test_offline_default_fixture(tmp_path: Path) -> None:
     fixture_src = Path(__file__).parent / "fixtures" / "commits.json"
     target = Path(pipeline.__file__).with_name("commits_fixture.json")
-    target.write_text(
-        fixture_src.read_text(encoding="utf-8"), encoding="utf-8"
-    )
+    target.write_text(fixture_src.read_text(encoding="utf-8"), encoding="utf-8")
     try:
         rows = pipeline.run(offline=True, pipelines_dir=tmp_path)
     finally:
@@ -33,16 +31,12 @@ def test_missing_commit_dates(tmp_path: Path) -> None:
     fixture = [{"sha": "1", "commit": {"author": {"name": "A"}}}]
     path = tmp_path / "missing_dates.json"
     path.write_text(json.dumps(fixture), encoding="utf-8")
-    rows = pipeline.run(
-        offline=True, fixture_path=path, pipelines_dir=tmp_path
-    )
+    rows = pipeline.run(offline=True, fixture_path=path, pipelines_dir=tmp_path)
     assert rows == []
 
 
 def test_no_commits(tmp_path: Path) -> None:
     path = tmp_path / "empty.json"
     path.write_text("[]", encoding="utf-8")
-    rows = pipeline.run(
-        offline=True, fixture_path=path, pipelines_dir=tmp_path
-    )
+    rows = pipeline.run(offline=True, fixture_path=path, pipelines_dir=tmp_path)
     assert rows == []


### PR DESCRIPTION
## Summary
- test commits source uses cursor.last_value for since param
- assert no Authorization header when GITHUB_TOKEN missing
- check HeaderLinkPaginator is used

## Testing
- `.codex/setup.sh`
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689afe04d1148325a46b14f32457382d