### PR TITLE
test: cover commits_flat transformer

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -245,3 +245,10 @@ Keep lines ≤ 80 chars and leave exactly **one blank line** between secti
 - **Stage**: testing
 - **Motivation / Decision**: ensure commits without timestamps return `None`.
 - **Next step**: broaden commit test scenarios.
+
+## 2025-08-12  PR #29
+
+- **Summary**: Added unit test for `commits_flat` transformer.
+- **Stage**: testing
+- **Motivation / Decision**: ensure transformer yields expected rows using a stub client.
+- **Next step**: broaden commit scenarios for `commits_flat`.

--- a/TODO.md
+++ b/TODO.md
@@ -80,3 +80,4 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [ ] Audit tests to ensure network calls are mocked or use offline fixtures (2025-08-12)
 - [ ] Audit other normalization helpers for whitespace handling (2025-08-12)
 - [x] Add tests for `flatten_commit` missing commit date (2025-08-12)
+- [x] Add unit test for `commits_flat` transformer (2025-08-12)

--- a/tests/test_commits_flat.py
+++ b/tests/test_commits_flat.py
@@ -1,0 +1,40 @@
+from typing import Any, Dict
+
+import pytest
+
+from src.gh_leaderboard import pipeline
+from src.gh_leaderboard.pipeline import github_commits_source
+
+
+class StubRESTClient:
+    def __init__(self, base_url: str, headers: Dict[str, Any]) -> None:
+        self.base_url = base_url
+        self.headers = headers
+
+    def paginate(self, path: str, params: Dict[str, Any], paginator: Any):
+        yield []
+
+
+def test_commits_flat(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pipeline, "RESTClient", StubRESTClient)
+    source = github_commits_source()
+    commits_flat = source.resources["commits_flat"]
+    commit = {
+        "sha": "abc123",
+        "author": {"login": "alice"},
+        "commit": {
+            "author": {
+                "name": "Alice",
+                "email": "alice@example.com",
+            },
+            "committer": {"date": "2024-01-01T10:00:00Z"},
+        },
+    }
+    assert list(commits_flat._pipe.gen(commit)) == [
+        {
+            "sha": "abc123",
+            "author_identity": "alice",
+            "commit_timestamp": "2024-01-01T10:00:00Z",
+            "commit_day": "2024-01-01",
+        }
+    ]

--- a/tests/test_run_edge_cases.py
+++ b/tests/test_run_edge_cases.py
@@ -7,9 +7,7 @@ from src.gh_leaderboard import pipeline
 def test_offline_default_fixture(tmp_path: Path) -> None:
     fixture_src = Path(__file__).parent / "fixtures" / "commits.json"
     target = Path(pipeline.__file__).with_name("commits_fixture.json")
-    target.write_text(
-        fixture_src.read_text(encoding="utf-8"), encoding="utf-8"
-    )
+    target.write_text(fixture_src.read_text(encoding="utf-8"), encoding="utf-8")
     try:
         rows = pipeline.run(offline=True, pipelines_dir=tmp_path)
     finally:
@@ -33,16 +31,12 @@ def test_missing_commit_dates(tmp_path: Path) -> None:
     fixture = [{"sha": "1", "commit": {"author": {"name": "A"}}}]
     path = tmp_path / "missing_dates.json"
     path.write_text(json.dumps(fixture), encoding="utf-8")
-    rows = pipeline.run(
-        offline=True, fixture_path=path, pipelines_dir=tmp_path
-    )
+    rows = pipeline.run(offline=True, fixture_path=path, pipelines_dir=tmp_path)
     assert rows == []
 
 
 def test_no_commits(tmp_path: Path) -> None:
     path = tmp_path / "empty.json"
     path.write_text("[]", encoding="utf-8")
-    rows = pipeline.run(
-        offline=True, fixture_path=path, pipelines_dir=tmp_path
-    )
+    rows = pipeline.run(offline=True, fixture_path=path, pipelines_dir=tmp_path)
     assert rows == []


### PR DESCRIPTION
## Summary
- add unit test for `commits_flat` using a stubbed REST client
- format existing edge-case test to satisfy linters
- record progress in NOTES and TODO

## Testing
- `bash .codex/setup.sh`
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689afe0391e4832588ec8e2210364486