### PR TITLE
test: cover committer date fallback

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -286,3 +286,10 @@ to CWD when `pipelines_dir` is omitted.
 - **Motivation / Decision**: verify default path behavior
 to avoid polluting repo root.
 - **Next step**: add online test for default path handling.
+
+## 2025-08-12  PR #34
+
+- **Summary**: Added test for author date fallback when committer date is missing.
+- **Stage**: testing
+- **Motivation / Decision**: confirm commits still flatten using author timestamp.
+- **Next step**: review remaining commit variants for coverage.

--- a/TODO.md
+++ b/TODO.md
@@ -86,3 +86,5 @@ when token missing (2025-08-12)
 - [x] Increase coverage threshold to ≥ 90 % (2025-08-12)
 - [x] Extend `flatten_commit` tests for missing login and commit key (2025-08-12)
 - [x] Add test for pipeline default DuckDB path when `pipelines_dir` is omitted (2025-08-12)
+- [x] Add test verifying author date fallback when committer date is missing
+      (2025-08-12)

--- a/tests/test_flatten_commit.py
+++ b/tests/test_flatten_commit.py
@@ -32,6 +32,22 @@ def commit_missing_date() -> dict:
 
 
 @pytest.fixture
+def commit_missing_committer_date() -> dict:
+    return {
+        "sha": "no-committer-date",
+        "author": {"login": "alice"},
+        "commit": {
+            "author": {
+                "name": "Alice",
+                "email": "alice@example.com",
+                "date": "2024-01-03T10:00:00Z",
+            },
+            "committer": {},
+        },
+    }
+
+
+@pytest.fixture
 def commit_missing_login() -> dict:
     return {
         "sha": "no-login",
@@ -63,6 +79,17 @@ def test_flatten_commit_normal(normal_commit: dict) -> None:
 
 def test_flatten_commit_missing_date(commit_missing_date: dict) -> None:
     assert flatten_commit(commit_missing_date) is None
+
+
+def test_flatten_commit_missing_committer_date(
+    commit_missing_committer_date: dict,
+) -> None:
+    assert flatten_commit(commit_missing_committer_date) == {
+        "sha": "no-committer-date",
+        "author_identity": "alice",
+        "commit_timestamp": "2024-01-03T10:00:00Z",
+        "commit_day": "2024-01-03",
+    }
 
 
 def test_flatten_commit_missing_login(commit_missing_login: dict) -> None:


### PR DESCRIPTION
## Summary
- test that `flatten_commit` uses author date when committer date is missing
- log new test in TODO and NOTES

## Testing
- `pre-commit run --all-files`
- `.venv/bin/pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689b03cba6b48325b4e186a161d1801c