### PR TITLE
Add test for initial incremental cursor and fix default DB path

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -319,3 +319,12 @@ to avoid polluting repo root.
 - **Motivation / Decision**: ensure leaderboard ignores commits missing
   timestamps.
 - **Next step**: surface skipped commits in future runs.
+
+## 2025-08-12  PR #38
+
+- **Summary**: Added test ensuring initial cursor value sets `since` and omits auth header; fixed default DuckDB path.
+- **Stage**: testing
+- **Motivation / Decision**: verify pipeline uses `initial_value` when state is
+  empty and avoids sending tokens; ensure `pipeline.run` writes database to the
+  current directory.
+- **Next step**: review other incremental scenarios.

--- a/TODO.md
+++ b/TODO.md
@@ -91,3 +91,5 @@ when token missing (2025-08-12)
 - [x] Add test verifying author date fallback when committer date is missing
       (2025-08-12)
 - [ ] Log or surface skipped commits lacking timestamps (2025-08-12)
+- [x] Test incremental cursor uses initial_value when state is empty (2025-08-12)
+- [x] Ensure `pipeline.run` writes DuckDB to current directory when `pipelines_dir` is omitted (2025-08-12)

--- a/src/gh_leaderboard/pipeline.py
+++ b/src/gh_leaderboard/pipeline.py
@@ -128,7 +128,7 @@ def run(
     db_path = (
         Path(pipelines_dir) / "leaderboard.duckdb"
         if pipelines_dir
-        else Path("leaderboard.duckdb")
+        else Path.cwd() / "leaderboard.duckdb"
     )
     pipeline = dlt.pipeline(
         pipeline_name="gh_leaderboard",

--- a/tests/test_github_commits_source_initial_value.py
+++ b/tests/test_github_commits_source_initial_value.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict
+
+import pytest
+
+from src.gh_leaderboard import pipeline
+from src.gh_leaderboard.pipeline import github_commits_source
+
+
+class StubRESTClient:
+    last_instance: "StubRESTClient | None" = None
+
+    def __init__(self, base_url: str, headers: Dict[str, Any]) -> None:
+        self.base_url = base_url
+        self.headers = headers
+        self.params: Dict[str, Any] = {}
+        StubRESTClient.last_instance = self
+
+    def paginate(self, path: str, params: Dict[str, Any], paginator: Any):
+        self.params = params
+        yield []
+
+
+def test_cursor_initial_value_and_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    original_incremental = pipeline.dlt.sources.incremental
+    IncrementalCls = original_incremental("cursor").__class__
+
+    class FakeIncremental(IncrementalCls):
+        @property
+        def last_value(self) -> None:  # type: ignore[override]
+            return None
+
+    def fake_incremental(*args: Any, **kwargs: Any) -> FakeIncremental:
+        inc = FakeIncremental(*args, **kwargs)
+        inc.initial_value = "2024-01-01T00:00:00Z"
+        return inc
+
+    monkeypatch.setattr(pipeline.dlt.sources, "incremental", fake_incremental)
+    monkeypatch.setattr(pipeline, "RESTClient", StubRESTClient)
+
+    source = github_commits_source()
+    commits = source.resources["commits"]
+    list(commits())
+    rest = StubRESTClient.last_instance
+    assert rest is not None
+    assert rest.params["since"] == "2024-01-01T00:00:00Z"
+    assert "Authorization" not in rest.headers


### PR DESCRIPTION
## Summary
- test that github commits source uses the incremental `initial_value` and omits the auth header when no token is present
- ensure `pipeline.run` writes DuckDB to the working directory when `pipelines_dir` is not provided
- log work in NOTES and TODO

## Testing
- `./.codex/setup.sh`
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689b0f25bd4083258a618447ea02473b