### PR TITLE
Handle blank author name in normalize_author

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -353,3 +353,12 @@ to avoid polluting repo root.
   empty and avoids sending tokens; ensure `pipeline.run` writes database to the
   current directory.
 - **Next step**: review other incremental scenarios.
+
+## 2025-08-12  PR #42
+
+- **Summary**: Added test for blank author name and made `normalize_author`
+  return "unknown".
+- **Stage**: testing
+- **Motivation / Decision**: ensure whitespace-only names fall back to
+  "unknown" per TODO.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -78,7 +78,7 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
       (2025-08-12)
 - [x] Add tests for GitHub commits source headers and params (2025-08-12)
 - [ ] Audit tests to ensure network calls are mocked or use offline fixtures (2025-08-12)
-- [ ] Audit other normalization helpers for whitespace handling (2025-08-12)
+- [x] Audit other normalization helpers for whitespace handling (2025-08-12)
 - [x] Add tests for `flatten_commit` missing commit date (2025-08-12)
 - [x] Add unit test for `commits_flat` transformer (2025-08-12)
 - [x] Test incremental cursor uses last_value and omits auth header

--- a/src/gh_leaderboard/pipeline.py
+++ b/src/gh_leaderboard/pipeline.py
@@ -29,7 +29,7 @@ def normalize_author(
     if email:
         local = email.split("@")[0].split("+")[0]
         return local.lower()
-    if name:
+    if name and name.strip():
         return name.strip().lower()
     return "unknown"
 

--- a/tests/test_normalize_author_cases.py
+++ b/tests/test_normalize_author_cases.py
@@ -8,3 +8,7 @@ def test_login_is_lowercased() -> None:
 def test_whitespace_login_falls_back() -> None:
     assert normalize_author("", "Bob@example.com", None) == "bob"
     assert normalize_author("   ", None, "Carol") == "carol"
+
+
+def test_blank_name_returns_unknown() -> None:
+    assert normalize_author(None, None, "   ") == "unknown"


### PR DESCRIPTION
## Summary
- treat whitespace-only author names as `unknown`
- add regression test for blank name case
- log change and tick roadmap item

## Testing
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689b15c4e80c8325bd7bf309cc16496d