### PR TITLE
Add markdownlint and actionlint hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,11 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-merge-conflict
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.45.0
+    hooks:
+      - id: markdownlint
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.16 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.17 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and
@@ -78,15 +78,17 @@ Studion 2022 on Win 11) to test manually.
    * Pass flags to pytest via `PYTEST_ARGS`, e.g. `make test
      PYTEST_ARGS="--offline"`.
 
-   ```bash
-   pre-commit run --all-files
-   .venv/bin/pytest --cov=src --cov-fail-under=90
-   ```
+    ```bash
+    pre-commit run --all-files
+    .venv/bin/pytest --cov=src --cov-fail-under=90
+    ```
 
-   * Coverage excludes `tests/**` and `generated/**` via `.coveragerc`.
-   * `pytest` fails when no tests are collected; ensure at least one exists.
+    * Coverage excludes `tests/**` and `generated/**` via `.coveragerc`.
+    * `pytest` fails when no tests are collected; ensure at least one exists.
 
-   Markdown lint rules live in `.markdownlint.json` for now.
+    Markdown lint rules live in `.markdownlint.json`.
+    Pre-commit also runs `markdownlint` and `actionlint` to lint docs and
+    workflows.
 3. **Test collection** – `make test` must fail if no tests are collected.
 4. **Style rules** – keep code formatted (`black`, `prettier`,
    `dart format`, etc.) and Markdown lines ≤ 80 chars; exactly **one

--- a/NOTES.md
+++ b/NOTES.md
@@ -384,3 +384,11 @@ to avoid polluting repo root.
 - **Stage**: testing
 - **Motivation / Decision**: cover argument forwarding and remove network dependency for CI stability.
 - **Next step**: audit other normalization helpers for whitespace handling.
+
+## 2025-08-12  PR #46
+
+- **Summary**: Added markdownlint and actionlint hooks to pre-commit and
+  reformatted a test.
+- **Stage**: maintenance
+- **Motivation / Decision**: pinned versions v0.45.0 and v1.7.7 to meet TODO.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -70,7 +70,7 @@ Repeat the five‑bullet block below for every MVP feature A, B, C, …
 - [x] Wrap lint and test commands in `AGENTS.md` code fence (2025-08-11)
 - [x] Replace `grep` with anchored `git grep` for conflict checks (2025-08-11)
 - [x] Revise conflict marker guidelines using placeholders in AGENTS.md (2025-08-12)
-- [ ] Add markdownlint and actionlint to pre-commit config (2025-08-12)
+- [x] Add markdownlint and actionlint to pre-commit config (2025-08-12)
 - [x] Run pre-commit hooks via `pre-commit run --all-files` in Makefile and CI
       (2025-08-12)
 - [x] Add `check-merge-conflict` hook to pre-commit config (2025-08-12)

--- a/tests/test_run_parameter_forwarding.py
+++ b/tests/test_run_parameter_forwarding.py
@@ -25,7 +25,13 @@ def test_run_parameter_forwarding(tmp_path: Path, monkeypatch: Any) -> None:
 
     db_path = tmp_path / "leaderboard.duckdb"
 
-    def fake_pipeline(*, pipeline_name: str, destination: Any, dataset_name: str, pipelines_dir: str | None) -> Any:
+    def fake_pipeline(
+        *,
+        pipeline_name: str,
+        destination: Any,
+        dataset_name: str,
+        pipelines_dir: str | None
+    ) -> Any:
         captured["pipeline"] = {
             "pipeline_name": pipeline_name,
             "dataset_name": dataset_name,


### PR DESCRIPTION
## Summary
- lint markdown and workflows via new markdownlint and actionlint pre-commit hooks
- note the new hooks in AGENTS and tick TODO with a log entry

## Testing
- `pre-commit run --all-files`
- `.venv/bin/pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689c3e960d888325accdaf5c60f94bf4