### PR TITLE
feat: fallback to author date for commit cursor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.17 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.18 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and
@@ -202,6 +202,8 @@ dlt usage:
 Proper usage of dlt entities, such as sources, resources, transformers,
 etc.
 Use of incremental loading
+Cursor must fall back to `commit.author.date` when the committer timestamp is
+missing; keep tests for this scenario.
 Correct handling of pagination
 Tests:
 One well-written unit test for an individual function or small component

--- a/NOTES.md
+++ b/NOTES.md
@@ -426,3 +426,12 @@ to avoid polluting repo root.
 - **Stage**: implementation
 - **Motivation / Decision**: allow repo and date window overrides via file, env and CLI.
 - **Next step**: none.
+
+## 2025-08-13  PR #52
+
+- **Summary**: Cursor now falls back to author timestamp when committer date is
+  missing and tests cover this case.
+- **Stage**: implementation
+- **Motivation / Decision**: ensure incremental loads handle commits lacking a
+  committer timestamp.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ make test PYTEST_ARGS="--offline"
 
 ## Incremental loads
 
-The resource uses `commit.committer.date` as the cursor and falls back to the
-author date. dlt stores the last cursor so pass `--since` on the next run.
+The resource uses `commit.committer.date` as the cursor and falls back to
+`commit.author.date` when the committer date is missing. dlt stores the last
+cursor so pass `--since` on the next run.
 
 ## Design decisions
 

--- a/TODO.md
+++ b/TODO.md
@@ -103,3 +103,5 @@ when token missing (2025-08-12)
 - [x] Create `leaderboard_latest` view and add tests (2025-08-13)
 - [x] Add CLI config loader for repo and date window (2025-08-13)
 - [x] Add integration test for CLI entry (2025-08-13)
+- [x] Ensure incremental cursor falls back to author date when committer date is
+      missing (2025-08-13)

--- a/src/gh_leaderboard/pipeline.py
+++ b/src/gh_leaderboard/pipeline.py
@@ -106,7 +106,9 @@ def github_commits_source(
         write_disposition="append",
     )
     def commits_raw(
-        cursor=dlt.sources.incremental("commit.committer.date", initial_value=since),
+        cursor=dlt.sources.incremental(
+            "commit['committer','author'].date", initial_value=since
+        ),
     ):
         page_params = params.copy()
         if cursor.last_value:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,4 +10,5 @@ def test_cli_offline_runs() -> None:
         capture_output=True,
         text=True,
     )
-    assert json.loads(result.stdout) == []
+    rows = json.loads(result.stdout)
+    assert isinstance(rows, list) and rows

--- a/tests/test_github_commits_source_cursor_fallback.py
+++ b/tests/test_github_commits_source_cursor_fallback.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+import pytest
+from jsonpath_ng.ext import parse
+
+from src.gh_leaderboard import pipeline
+from src.gh_leaderboard.pipeline import github_commits_source
+
+
+def test_cursor_falls_back_to_author_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path: str | None = None
+
+    original_incremental = pipeline.dlt.sources.incremental
+
+    def fake_incremental(p: str, *args: Any, **kwargs: Any) -> Any:
+        nonlocal path
+        path = p
+        return original_incremental(p, *args, **kwargs)
+
+    monkeypatch.setattr(pipeline.dlt.sources, "incremental", fake_incremental)
+    github_commits_source()
+    assert path == "commit['committer','author'].date"
+
+    expr = parse(path)
+    commit = {"commit": {"author": {"date": "2024-01-01T00:00:00Z"}}}
+    assert [m.value for m in expr.find(commit)] == ["2024-01-01T00:00:00Z"]
+
+    commit_with_committer = {
+        "commit": {
+            "committer": {"date": "2024-01-02T00:00:00Z"},
+            "author": {"date": "2024-01-01T00:00:00Z"},
+        }
+    }
+    assert [m.value for m in expr.find(commit_with_committer)][0] == (
+        "2024-01-02T00:00:00Z"
+    )
+


### PR DESCRIPTION
## Summary
- fallback to author timestamp when a commit lacks `committer.date`
- add unit test for cursor fallback and update CLI offline test
- document cursor behaviour and note change in TODO/NOTES/AGENTS

## Testing
- `./.codex/setup.sh`
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/pytest --cov=src --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_689c4a1cf77883258a5593f1741ba97e