### PR TITLE
chore: rename dataset to github_leaderboard

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -435,3 +435,10 @@ to avoid polluting repo root.
 - **Motivation / Decision**: ensure incremental loads handle commits lacking a
   committer timestamp.
 - **Next step**: none.
+
+## 2025-08-13  PR #53
+
+- **Summary**: Renamed dataset to `github_leaderboard` and updated tests and docs.
+- **Stage**: implementation
+- **Motivation / Decision**: align dataset name with specification.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ rows = pipeline.run(
     until="2012-03-07T00:00:00Z",
 )
 p = dlt.pipeline(
-    "gh_leaderboard", destination="duckdb", dataset_name="gh_leaderboard"
+    "gh_leaderboard", destination="duckdb", dataset_name="github_leaderboard"
 )
 with p.sql_client() as sql:
     print(

--- a/TODO.md
+++ b/TODO.md
@@ -105,3 +105,4 @@ when token missing (2025-08-12)
 - [x] Add integration test for CLI entry (2025-08-13)
 - [x] Ensure incremental cursor falls back to author date when committer date is
       missing (2025-08-13)
+- [x] Rename dataset to `github_leaderboard` across code and docs (2025-08-13)

--- a/docs/dlt_guide_for_codex_2025.txt
+++ b/docs/dlt_guide_for_codex_2025.txt
@@ -359,7 +359,7 @@ def events_to_leaderboard(event):
 
 # Pipeline runner
 if __name__ == "__main__":
-    pipeline = dlt.pipeline("gh_leaderboard", destination="duckdb", dataset_name="github_ds")
+    pipeline = dlt.pipeline("gh_leaderboard", destination="duckdb", dataset_name="github_leaderboard")
     # Pipe operator connects resource → transformer; we load only the derived table here
     pipeline.run((repo_events | events_to_leaderboard).with_resources("daily_leaderboard"))
 

--- a/src/gh_leaderboard/pipeline.py
+++ b/src/gh_leaderboard/pipeline.py
@@ -153,7 +153,7 @@ def run(
     pipeline = dlt.pipeline(
         pipeline_name="gh_leaderboard",
         destination=dlt.destinations.duckdb(str(db_path)),
-        dataset_name="gh_leaderboard",
+        dataset_name="github_leaderboard",
         pipelines_dir=str(pipelines_dir) if pipelines_dir else None,
     )
 

--- a/tests/test_github_commits_source_cursor_fallback.py
+++ b/tests/test_github_commits_source_cursor_fallback.py
@@ -36,4 +36,3 @@ def test_cursor_falls_back_to_author_date(
     assert [m.value for m in expr.find(commit_with_committer)][0] == (
         "2024-01-02T00:00:00Z"
     )
-

--- a/tests/test_leaderboard_latest_view.py
+++ b/tests/test_leaderboard_latest_view.py
@@ -12,18 +12,18 @@ def test_leaderboard_latest_view(tmp_path: Path) -> None:
     conn = duckdb.connect(tmp_path / "leaderboard.duckdb")
     views = conn.execute(
         "select lower(table_name) from information_schema.views"
-        " where table_schema = 'gh_leaderboard'"
+        " where table_schema = 'github_leaderboard'"
         " and table_name = 'leaderboard_latest'"
     ).fetchall()
     assert views == [("leaderboard_latest",)]
 
     count = conn.execute(
-        "select count(*) from gh_leaderboard.leaderboard_latest"
+        "select count(*) from github_leaderboard.leaderboard_latest"
     ).fetchone()[0]
     assert count == 2
 
     rows = conn.execute(
-        "select commit_day from gh_leaderboard.leaderboard_latest"
+        "select commit_day from github_leaderboard.leaderboard_latest"
         " order by commit_day"
     ).fetchall()
     assert rows == [("2024-01-02",), ("2024-01-03",)]

--- a/tests/test_pipeline_offline.py
+++ b/tests/test_pipeline_offline.py
@@ -23,7 +23,7 @@ def test_pipeline_offline(tmp_path: Path) -> None:
     p = dlt.pipeline(
         "gh_leaderboard",
         destination=dlt.destinations.duckdb(str(tmp_path / "leaderboard.duckdb")),
-        dataset_name="gh_leaderboard",
+        dataset_name="github_leaderboard",
         pipelines_dir=str(tmp_path),
     )
     with p.sql_client() as sql:

--- a/tests/test_run_parameter_forwarding.py
+++ b/tests/test_run_parameter_forwarding.py
@@ -79,7 +79,7 @@ def test_run_parameter_forwarding(tmp_path: Path, monkeypatch: Any) -> None:
     }
     assert captured["pipeline"] == {
         "pipeline_name": "gh_leaderboard",
-        "dataset_name": "gh_leaderboard",
+        "dataset_name": "github_leaderboard",
         "pipelines_dir": str(tmp_path),
     }
     assert db_path.exists()


### PR DESCRIPTION
## Summary
- rename dlt pipeline dataset to `github_leaderboard`
- align tests and docs with new dataset name
- log the change in project notes

## Testing
- `pre-commit run --all-files`
- `pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689c50ab064c83259186a94aa39e87f7