### PR TITLE
chore: ignore local secrets and update guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .dlt/state*
+.dlt/secrets.toml
 *.duckdb
 .venv/
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Contributor & CI Guide  <!-- AGENTS.md v1.18 -->
+# Contributor & CI Guide  <!-- AGENTS.md v1.19 -->
 
 > **Read this file first** before opening a pull‑request.
 > It defines the ground rules that keep humans, autonomous agents and
@@ -227,5 +227,11 @@ Pin your dependencies
 * When CI tooling changes (new Action versions, new secrets, extra
   language runners) **update both** this guide **and** the workflow
   file in the **same PR**.
+
+## 7 · Security
+
+* Never commit secrets or credentials.
+* Keep secret files like `.dlt/secrets.toml` out of version control.
+* Scan commits locally for stray secrets before pushing.
 
 Happy shipping 🚀

--- a/NOTES.md
+++ b/NOTES.md
@@ -449,3 +449,10 @@ to avoid polluting repo root.
 - **Stage**: implementation
 - **Motivation / Decision**: align dataset name with specification.
 - **Next step**: none.
+
+## 2025-08-13  PR #55
+
+- **Summary**: Added `.dlt/secrets.toml` to `.gitignore` and warned against committing secrets.
+- **Stage**: maintenance
+- **Motivation / Decision**: protect credentials by ignoring secret files and updating guidelines.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -107,3 +107,5 @@ when token missing (2025-08-12)
       missing (2025-08-13)
 - [x] Document `leaderboard_latest` view in README and examples (2025-08-13)
 - [x] Rename dataset to `github_leaderboard` across code and docs (2025-08-13)
+- [x] Add `.dlt/secrets.toml` to `.gitignore` and warn against committing
+      secrets (2025-08-13)


### PR DESCRIPTION
## Summary
- ignore `.dlt/secrets.toml`
- document secret handling in contributor guide
- log the change in NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check AGENTS.md NOTES.md TODO.md`
- `git grep -nE '^<{7}|^={7}|^>{7}' -- && exit 1 || echo 'No conflict markers'`


------
https://chatgpt.com/codex/tasks/task_e_689c553e07f88325af3135e3b3c9fd94