### PR TITLE
docs: add troubleshooting guidance

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -449,3 +449,11 @@ to avoid polluting repo root.
 - **Stage**: implementation
 - **Motivation / Decision**: align dataset name with specification.
 - **Next step**: none.
+
+## 2025-08-13  PR #55
+
+- **Summary**: Added troubleshooting section to README for common errors.
+- **Stage**: documentation
+- **Motivation / Decision**: help users resolve rate limits, empty results,
+  and offline use.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Forward extra flags with `PYTEST_ARGS`. For example, skip network tests:
 make test PYTEST_ARGS="--offline"
 ```
 
+## Troubleshooting
+
+* 403 or pagination stalls → set `GITHUB_TOKEN`; ensure `per_page=100`.
+* Empty results → adjust `--since/--until`; confirm branch.
+* Codex: no internet → use `--offline`.
+
 ## Incremental loads
 
 The resource uses `commit.committer.date` as the cursor and falls back to

--- a/TODO.md
+++ b/TODO.md
@@ -107,3 +107,5 @@ when token missing (2025-08-12)
       missing (2025-08-13)
 - [x] Document `leaderboard_latest` view in README and examples (2025-08-13)
 - [x] Rename dataset to `github_leaderboard` across code and docs (2025-08-13)
+- [x] Document troubleshooting tips for common pipeline errors in README
+      (2025-08-13)


### PR DESCRIPTION
## Summary
- add troubleshooting section to README with tips for rate limits, empty results, and offline runs
- log the change in NOTES and mark roadmap item in TODO

## Testing
- `pre-commit run --files README.md NOTES.md TODO.md`

------
https://chatgpt.com/codex/tasks/task_e_689c5523a6f883259a21899f27af688b