### PR TITLE
feat: load window-days and token from config

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -490,3 +490,10 @@ to avoid polluting repo root.
 - **Stage**: implementation
 - **Motivation / Decision**: avoid missing tables when fixture yields no commits; kept SQL flow intact.
 - **Next step**: none.
+
+## 2025-08-13 PR #61
+
+- **Summary**: Added window_days defaults and token from secrets.
+- **Stage**: implementation
+- **Motivation / Decision**: auto compute dates and load GitHub token securely.
+- **Next step**: pipe config token into pipeline.

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ It creates three tables and one view:
        print(sql.execute_sql("select * from leaderboard_latest"))
    ```
 
-Set `GITHUB_TOKEN` to raise rate limits if needed.
+Set `GITHUB_TOKEN` or add `[github].token` to `.dlt/secrets.toml` to raise rate
+limits if needed.
 
-Defaults for repository, branch and date window come from `.dlt/config.toml`
-or environment variables `GH_REPO`, `GH_BRANCH`, `GH_SINCE_ISO`,
+Defaults for repository, branch and date window come from `[gh]` in
+`.dlt/config.toml` or environment variables `GH_REPO`, `GH_BRANCH`, `GH_SINCE_ISO`,
 `GH_UNTIL_ISO`. Command line flags override these values:
 
 ```bash
@@ -132,7 +133,6 @@ make test PYTEST_ARGS="--offline"
 * 403 or pagination stalls → set `GITHUB_TOKEN`; ensure `per_page=100`.
 * Empty results → adjust `--since/--until`; confirm branch.
 * Codex: no internet → use `--offline`.
-=======
 Run just the offline end-to-end test:
 
 ```bash
@@ -144,7 +144,7 @@ The resource uses `commit.committer.date` as the cursor and falls back to
 `commit.author.date` when the committer date is missing. dlt stores the last
 cursor so pass `--since` on the next run.
 
-## Troubleshooting
+## Troubleshooting details
 
 ### HTTP 403 from GitHub
 

--- a/TODO.md
+++ b/TODO.md
@@ -115,3 +115,6 @@ when token missing (2025-08-12)
 - [x] Rename offline pipeline test with e2e tag and document run command (2025-08-13)
 - [x] Handle GitHub API 403 errors with RuntimeError and tests (2025-08-13)
 - [x] Ensure pipeline creates empty commit tables when no commits are loaded (2025-08-13)
+
+- [x] Load GitHub token from .dlt/secrets.toml and compute window_days defaults (2025-08-13)
+- [ ] Pass Settings.token through pipeline instead of env var (2025-08-13)

--- a/src/gh_leaderboard/config.py
+++ b/src/gh_leaderboard/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -18,6 +19,25 @@ class Settings:
     branch: Optional[str] = None
     since: Optional[str] = None
     until: Optional[str] = None
+    token: Optional[str] = None
+
+
+def _read_toml(path: Path) -> dict[str, object]:
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+
+def _iso(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat() + "Z"
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def load_config(path: str | Path = Path(".dlt/config.toml")) -> Settings:
@@ -28,16 +48,43 @@ def load_config(path: str | Path = Path(".dlt/config.toml")) -> Settings:
     """
 
     path = Path(path)
-    data: dict[str, object] = {}
-    if path.is_file():
-        try:
-            data = tomllib.loads(path.read_text(encoding="utf-8"))
-        except (OSError, tomllib.TOMLDecodeError):
-            data = {}
-    defaults = data.get("gh_leaderboard", {}) if isinstance(data, dict) else {}
-    return Settings(
-        repo=os.environ.get("GH_REPO", defaults.get("repo", "octocat/Hello-World")),
-        branch=os.environ.get("GH_BRANCH", defaults.get("branch")),
-        since=os.environ.get("GH_SINCE_ISO", defaults.get("since")),
-        until=os.environ.get("GH_UNTIL_ISO", defaults.get("until")),
-    )
+    data: dict[str, object] = _read_toml(path) if path.is_file() else {}
+    defaults = data.get("gh", {}) if isinstance(data, dict) else {}
+
+    repo = os.environ.get("GH_REPO", defaults.get("repo", "octocat/Hello-World"))
+    branch = os.environ.get("GH_BRANCH", defaults.get("branch"))
+    since = os.environ.get("GH_SINCE_ISO", defaults.get("since"))
+    until = os.environ.get("GH_UNTIL_ISO", defaults.get("until"))
+    window_days = defaults.get("window_days")
+
+    try:
+        days = int(window_days) if window_days is not None else None
+    except (TypeError, ValueError):
+        days = None
+
+    if days:
+        if since and not until:
+            start = _parse_iso(since)
+            if start:
+                until = _iso(start + timedelta(days=days))
+        elif until and not since:
+            end = _parse_iso(until)
+            if end:
+                since = _iso(end - timedelta(days=days))
+        elif not since and not until:
+            end = datetime.utcnow()
+            until = _iso(end)
+            since = _iso(end - timedelta(days=days))
+
+    token: Optional[str] = None
+    secrets_path = path.with_name("secrets.toml")
+    if secrets_path.is_file():
+        secrets_data = _read_toml(secrets_path)
+        if isinstance(secrets_data, dict):
+            github = secrets_data.get("github", {})
+            if isinstance(github, dict):
+                token = github.get("token")
+    if token is None:
+        token = os.environ.get("GITHUB_TOKEN")
+
+    return Settings(repo=repo, branch=branch, since=since, until=until, token=token)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,41 +1,55 @@
+from datetime import datetime
 from pathlib import Path
 
-from src.gh_leaderboard.config import load_config
+import src.gh_leaderboard.config as cfg
 
 
-def _write_config(tmp_path: Path) -> Path:
+def _write_config(tmp_path: Path, body: str = "") -> Path:
     cfg_dir = tmp_path / ".dlt"
     cfg_dir.mkdir()
     cfg_file = cfg_dir / "config.toml"
-    cfg_file.write_text(
-        """[gh_leaderboard]
-repo="r1"
-branch="b1"
-since="2024-01-01T00:00:00Z"
-until="2024-01-15T00:00:00Z"
-""",
-        encoding="utf-8",
-    )
+    cfg_file.write_text(f'[gh]\nrepo="r1"\nbranch="b1"\n{body}', encoding="utf-8")
     return cfg_file
 
 
-def test_load_config_file(tmp_path: Path) -> None:
-    cfg_file = _write_config(tmp_path)
-    settings = load_config(cfg_file)
-    assert settings.repo == "r1"
-    assert settings.branch == "b1"
-    assert settings.since == "2024-01-01T00:00:00Z"
+class _FixedDatetime(datetime):
+    @classmethod
+    def utcnow(cls):
+        return cls(2024, 1, 15, 0, 0, 0)
+
+
+def test_window_days_computation(tmp_path: Path, monkeypatch) -> None:
+    cfg_file = _write_config(tmp_path, "window_days=7\n")
+    monkeypatch.setattr(cfg, "datetime", _FixedDatetime)
+    settings = cfg.load_config(cfg_file)
+    assert settings.since == "2024-01-08T00:00:00Z"
     assert settings.until == "2024-01-15T00:00:00Z"
 
 
 def test_env_overrides(tmp_path: Path, monkeypatch) -> None:
-    cfg_file = _write_config(tmp_path)
+    cfg_file = _write_config(tmp_path, "window_days=7\n")
     monkeypatch.setenv("GH_REPO", "r2")
     monkeypatch.setenv("GH_BRANCH", "b2")
     monkeypatch.setenv("GH_SINCE_ISO", "2024-02-01T00:00:00Z")
     monkeypatch.setenv("GH_UNTIL_ISO", "2024-02-15T00:00:00Z")
-    settings = load_config(cfg_file)
+    settings = cfg.load_config(cfg_file)
     assert settings.repo == "r2"
     assert settings.branch == "b2"
     assert settings.since == "2024-02-01T00:00:00Z"
     assert settings.until == "2024-02-15T00:00:00Z"
+
+
+def test_token_from_secrets(tmp_path: Path, monkeypatch) -> None:
+    cfg_file = _write_config(tmp_path)
+    secrets = cfg_file.with_name("secrets.toml")
+    secrets.write_text('[github]\ntoken="s3cret"', encoding="utf-8")
+    monkeypatch.setenv("GITHUB_TOKEN", "envtok")
+    settings = cfg.load_config(cfg_file)
+    assert settings.token == "s3cret"
+
+
+def test_token_from_env(tmp_path: Path, monkeypatch) -> None:
+    cfg_file = _write_config(tmp_path)
+    monkeypatch.setenv("GITHUB_TOKEN", "envtok")
+    settings = cfg.load_config(cfg_file)
+    assert settings.token == "envtok"


### PR DESCRIPTION
## Summary
- read GitHub repo settings from `[gh]` in `.dlt/config.toml`
- derive `since`/`until` from `window_days` and read token from `.dlt/secrets.toml`
- document config and secrets usage

## Testing
- `pre-commit run --all-files`
- `.venv/bin/pytest --cov=src --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_689c628f7e6c832593c099400b90d6d0