### PR TITLE
Add overlap to incremental cursor

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -565,3 +565,11 @@ to avoid polluting repo root.
 - **Stage**: implementation
 - **Motivation / Decision**: prevent duplicate commits when API returns same data.
 - **Next step**: none.
+
+## 2025-08-14 PR #72
+
+- **Summary**: Added 1-minute overlap for incremental cursor and updated tests.
+- **Stage**: implementation
+- **Motivation / Decision**: avoid missing commits near page boundaries;
+  updated tests to assert overlapped `since` values.
+- **Next step**: none.

--- a/TODO.md
+++ b/TODO.md
@@ -127,3 +127,4 @@ when token missing (2025-08-12)
 - [x] Document `write_disposition="merge"` requirement for primary-key dlt
       resources (2025-08-14)
 - [x] Ensure online pipeline deduplicates commits by SHA via merge (2025-08-13)
+- [x] Overlap incremental cursor by 60s and update tests (2025-08-14)

--- a/tests/test_github_commits_source.py
+++ b/tests/test_github_commits_source.py
@@ -58,10 +58,10 @@ def test_sha_and_until_params(rest_client: type[StubRESTClient]) -> None:
 
 
 def test_incremental_adds_since(rest_client: type[StubRESTClient]) -> None:
-    source = github_commits_source(since="2024-01-01")
+    source = github_commits_source(since="2024-01-01T00:00:00Z")
     commits = source.resources["commits_raw"]
     list(commits())
-    assert rest_client.last_instance.params["since"] == "2024-01-01"
+    assert rest_client.last_instance.params["since"] == "2023-12-31T23:59:00Z"
 
 
 def test_client_base_url_and_per_page_default(

--- a/tests/test_github_commits_source_cursor.py
+++ b/tests/test_github_commits_source_cursor.py
@@ -46,6 +46,6 @@ def test_cursor_last_value_and_headers(monkeypatch: pytest.MonkeyPatch) -> None:
     list(commits())
     rest = StubRESTClient.last_instance
     assert rest is not None
-    assert rest.params["since"] == "2024-02-02T00:00:00Z"
+    assert rest.params["since"] == "2024-02-01T23:59:00Z"
     assert "Authorization" not in rest.headers
     assert isinstance(rest.paginator, HeaderLinkPaginator)

--- a/tests/test_github_commits_source_initial_value.py
+++ b/tests/test_github_commits_source_initial_value.py
@@ -44,5 +44,5 @@ def test_cursor_initial_value_and_headers(monkeypatch: pytest.MonkeyPatch) -> No
     list(commits())
     rest = StubRESTClient.last_instance
     assert rest is not None
-    assert rest.params["since"] == "2024-01-01T00:00:00Z"
+    assert rest.params["since"] == "2023-12-31T23:59:00Z"
     assert "Authorization" not in rest.headers

--- a/tests/test_pipeline_online_idempotent.py
+++ b/tests/test_pipeline_online_idempotent.py
@@ -10,7 +10,6 @@ import pytest
 from src.gh_leaderboard import pipeline
 
 
-
 def test_pipeline_online_idempotent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -22,9 +21,7 @@ def test_pipeline_online_idempotent(
             self.base_url = base_url
             self.headers = headers
 
-        def paginate(
-            self, path: str, params: Dict[str, Any], paginator: Any
-        ) -> Any:
+        def paginate(self, path: str, params: Dict[str, Any], paginator: Any) -> Any:
             yield commits
 
     monkeypatch.setattr(pipeline, "RESTClient", StubRESTClient)


### PR DESCRIPTION
## Summary
- subtract 60s from incremental cursor start to avoid missing commits
- adjust cursor tests to expect overlapped timestamps
- document overlap behaviour and check off TODO

## Testing
- `pre-commit run --all-files`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689d81e61d048325800814044d8f2b70