### PR TITLE
docs: add token and requirements notes

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -622,3 +622,12 @@ to avoid polluting repo root.
   pipeline runs; chose tenacity for concise retry logic and patched tests to
   simulate rate limits.
 - **Next step**: explore alternative destinations like BigQuery or Snowflake.
+
+## 2025-08-14 PR #79
+
+- **Summary**: Updated README with requirements, token steps, run commands,
+  and a rate-limit playbook.
+- **Stage**: documentation
+- **Motivation / Decision**: guide new users and show how to recover after
+  GitHub resets limits.
+- **Next step**: none.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This project is a small [dlt](https://dlthub.com/) pipeline that loads recent
 GitHub commits into DuckDB and builds a daily leaderboard of contributors.
 
+## Requirements
+
+* Python ≥ 3.10
+* DuckDB ≥ 1.3.2
+
 See [docs/specs.txt](docs/specs.txt) for the master specification and
 [docs/acceptance_criteria.md](docs/acceptance_criteria.md) for goals and
 edge cases.
@@ -50,8 +55,41 @@ It creates three tables and one view:
        print(sql.execute_sql("select * from leaderboard_latest"))
    ```
 
-Set `GITHUB_TOKEN` or add `[github].token` to `.dlt/secrets.toml` to raise rate
-limits if needed.
+### Personal access token
+
+In GitHub, create a token with `repo` and `read:user` scopes under
+Settings → Developer settings → Personal access tokens.
+
+```bash
+export GITHUB_TOKEN=...
+```
+
+### Commands
+
+* Offline run
+
+  ```bash
+  python -m src.gh_leaderboard.pipeline --offline
+  ```
+
+* Online run
+
+  ```bash
+  python -m src.gh_leaderboard.pipeline
+  ```
+
+* Tests
+
+  ```bash
+  pre-commit run --all-files
+  make test
+  ```
+
+* CI bootstrap
+
+  ```bash
+  ./.codex/setup.sh
+  ```
 
 Defaults for repository, branch and date window come from `[gh]` in
 `.dlt/config.toml` or environment variables `GH_REPO`, `GH_BRANCH`, `GH_SINCE_ISO`,
@@ -152,6 +190,22 @@ Run just the offline end-to-end test:
 ```bash
 pytest -q -k e2e --offline
 ```
+
+## Rate limit playbook
+
+GitHub resets API limits roughly once an hour. If a run fails with 403,
+wait for the reset and rerun:
+
+```bash
+python -m src.gh_leaderboard.pipeline
+```
+
+Check the reset time with:
+
+```bash
+curl -I https://api.github.com/rate_limit
+```
+
 ## Incremental loads
 
 The resource uses `commit.committer.date` as the cursor and falls back to

--- a/TODO.md
+++ b/TODO.md
@@ -136,3 +136,5 @@ when token missing (2025-08-12)
 - [x] Overlap incremental cursor by 60s and update tests (2025-08-14)
 - [x] Clarify idempotent reruns and 60s cursor overlap in docs (2025-08-14)
 - [x] Deduplicate `commits_raw` by SHA and test row count stability (2025-08-14)
+- [x] Document requirements, token setup, run commands and rate-limit playbook
+      in README (2025-08-14)


### PR DESCRIPTION
## Summary
- document Python and DuckDB version requirements
- explain how to create/export a GitHub personal access token
- add common run, test, and setup commands plus a rate-limit playbook

## Testing
- `pre-commit run --files README.md NOTES.md TODO.md`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d97cd5b20832590d186d01ae07a35